### PR TITLE
Remove `MalformedPointer` from `Pointer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+-   Adds `CHANGELOG.md` which will be better upkept moving forward.
+-   Adds `MaybePointer` to assist with deserialization which should not fail fast.
+
+### Changed
+
+-   `Pointer::new` now accepts a generic list, so `&["example"]` can be replaced by `["example"]`. For untyped, empty slices (i.e. `Pointer::new(&[])`), use `Pointer::default()`.
+-   `std` is now enabled by default.
+
+### Removed
+
+-   Removes optional `MalformedPointerError` from `Pointer`.
+
+## [0.3.6] 2023-05-23
+
+### Changed
+
+-   Adds quotes around `Pointer` debug output (#11)
+
+### Fixed
+
+-   Adds missing `impl std::error::Error` for `Error`, `NotFoundError`, `MalformedError`
+-   Fixes build for `std` feature flag
+
+## [0.3.4] 2023-05-11
+
+### Added
+
+-   Adds feature flag `fluent-uri` for `From<fluent_uri::Uri<_>` impl (#3)
+
+## [0.2.0] 2023-02-24
+
+### Changed
+
+-   `std` is now optional
+-   Adds feature flags `"uniresid"`, `"url"` to enable implementing `From<Uri>`, `From<Url>` (respectively).
+
+### Removed
+
+-   Removes `Cargo.lock`
+-   Makes `uniresid` and `uri` optional
+
+## [0.1.0] - 2022-06-12
+
+### Fixed
+
+-   Fixes root pointer representation `""` rather than the erroneous `"/"`
+-   Fixes an issue where encoded tokens were not being resolved properly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] 2023-05-31
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords      = ["json-pointer", "rfc-6901", "6901"]
 license       = "MIT OR Apache-2.0"
 name          = "jsonptr"
 repository    = "https://github.com/chanced/jsonptr"
-version       = "0.3.6"
+version       = "0.4.0"
 
 [dependencies]
 fluent-uri = { version = "0.1.4", optional = true, default-features = false }
@@ -18,5 +18,5 @@ uniresid   = { version = "0.1.4", optional = true }
 url        = { version = "2", optional = true }
 
 [features]
-default = []
+default = ["std"]
 std     = ["serde/std", "serde_json/std", "fluent-uri?/std"]

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -7,12 +7,12 @@ pub trait Delete {
     /// Error associated with `Delete`
     type Error;
     /// Attempts to internally delete a value based upon a [Pointer].
-    fn delete(&mut self, ptr: &Pointer) -> Result<Option<Value>, Self::Error>;
+    fn delete(&mut self, ptr: &Pointer) -> Option<Value>;
 }
 
 impl Delete for Value {
     type Error = MalformedPointerError;
-    fn delete(&mut self, ptr: &Pointer) -> Result<Option<Value>, Self::Error> {
+    fn delete(&mut self, ptr: &Pointer) -> Option<Value> {
         ptr.delete(self)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,8 +24,8 @@ pub enum Error {
     Unresolvable(UnresolvableError),
     /// Indicates that a Pointer was not found in the data.
     NotFound(NotFoundError),
-    /// Indicates that a Pointer was malformed.
-    MalformedPointer(MalformedPointerError),
+    // /// Indicates that a Pointer was malformed.
+    // MalformedPointer(MalformedPointerError),
 }
 
 impl Error {
@@ -41,16 +41,16 @@ impl Error {
     pub fn is_not_found(&self) -> bool {
         matches!(self, Error::NotFound(_))
     }
-    /// Returns `true` if the error is `Error::MalformedPointerError`.
-    pub fn is_malformed_pointer(&self) -> bool {
-        matches!(self, Error::MalformedPointer(_))
-    }
+    // /// Returns `true` if the error is `Error::MalformedPointerError`.
+    // pub fn is_malformed_pointer(&self) -> bool {
+    //     matches!(self, Error::MalformedPointer(_))
+    // }
 }
-impl From<MalformedPointerError> for Error {
-    fn from(err: MalformedPointerError) -> Self {
-        Error::MalformedPointer(err)
-    }
-}
+// impl From<MalformedPointerError> for Error {
+//     fn from(err: MalformedPointerError) -> Self {
+//         Error::MalformedPointer(err)
+//     }
+// }
 impl From<IndexError> for Error {
     fn from(err: IndexError) -> Self {
         Error::Index(err)
@@ -80,7 +80,7 @@ impl Display for Error {
             Error::Index(err) => Display::fmt(err, f),
             Error::Unresolvable(err) => Display::fmt(err, f),
             Error::NotFound(err) => Display::fmt(err, f),
-            Error::MalformedPointer(err) => Display::fmt(err, f),
+            // Error::MalformedPointer(err) => Display::fmt(err, f),
         }
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -147,6 +147,44 @@ impl From<&str> for Token {
         Token::new(s)
     }
 }
+impl From<&String> for Token {
+    fn from(value: &String) -> Self {
+        Token::new(value.as_str())
+    }
+}
+
+impl From<&&str> for Token {
+    fn from(value: &&str) -> Self {
+        Token::new(*value)
+    }
+}
+
+impl From<&usize> for Token {
+    fn from(value: &usize) -> Self {
+        Token::new(value.to_string())
+    }
+}
+impl From<u32> for Token {
+    fn from(v: u32) -> Self {
+        Token::new(v.to_string())
+    }
+}
+impl From<&u32> for Token {
+    fn from(v: &u32) -> Self {
+        Token::new(v.to_string())
+    }
+}
+impl From<u64> for Token {
+    fn from(v: u64) -> Self {
+        Token::new(v.to_string())
+    }
+}
+impl From<&u64> for Token {
+    fn from(v: &u64) -> Self {
+        Token::new(v.to_string())
+    }
+}
+
 impl From<String> for Token {
     fn from(value: String) -> Self {
         Token::new(value)


### PR DESCRIPTION
- Enables `"std"` by default
- Removes `MalformedPointer` from `Pointer` (#2)
- Adds `MaybePointer` for situations where deserialization should not fail when a `Pointer` is malformed.
- Changes signature for `Pointer::new` to allow for any type which implements `AsRef<[T]>` where `Token` implements `From<&T>`
- Adds CHANGELOG.md
