### PR TITLE
`Pointer::pop_front`: Correctly handle empty strings

### DIFF
--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -227,8 +227,11 @@ impl Pointer {
         }
         self.inner[1..]
             .split_once('/')
-            .map_or(Some((&self.inner[1..], "")), Option::Some)
-            .map(|(front, _)| Token::from_encoded(front))
+            .map_or_else(
+                || Token::from_encoded(&self.inner[1..]),
+                |(front, _)| Token::from_encoded(front),
+            )
+            .into()
     }
     /// Returns the first `Token` in the `Pointer`.
     ///
@@ -1414,7 +1417,7 @@ mod tests {
                 assert_eq!(ptr.pop_front().unwrap().as_str(), *s);
             }
             assert_eq!(ptr.tokens().count(), 0);
-            assert!(ptr.back().is_none());
+            assert!(ptr.front().is_none());
             assert!(ptr.pop_front().is_none());
         }
     }

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -169,21 +169,19 @@ impl Pointer {
     }
     /// Removes and returns the first `Token` in the `Pointer` if it exists.
     pub fn pop_front(&mut self) -> Option<Token> {
-        if !self.inner.is_empty() && self.count > 0 {
+        (!self.inner.is_empty() && self.count > 0).then(|| {
             self.count -= 1;
 
             if let Some((front, back)) = self.inner[1..].split_once('/') {
                 let front = Token::from_encoded(front);
                 self.inner = String::from("/") + back;
-                Some(front)
+                front
             } else {
                 let token = Token::from_encoded(&self.inner[1..]);
                 self.inner.truncate(0);
-                Some(token)
+                token
             }
-        } else {
-            None
-        }
+        })
     }
     /// Returns the number of tokens in the `Pointer`.
     pub fn count(&self) -> usize {


### PR DESCRIPTION
Counterpart of #25 for `Pointer::pop_front`.