### PR TITLE
Rework `Token` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-This is a breaking release including [#30](https://github.com/chanced/jsonptr/pull/30) by [@asmello](https://github.com/asmello)
+This is a breaking release including [#30](https://github.com/chanced/jsonptr/pull/30) and [#37](https://github.com/chanced/jsonptr/pull/37) by [@asmello](https://github.com/asmello)
 
 ### Added
 
@@ -16,14 +16,16 @@ This is a breaking release including [#30](https://github.com/chanced/jsonptr/pu
 -   Zero-allocation `Pointer::root` singleton pointer
 -   [Quickcheck](https://docs.rs/quickcheck/latest/quickcheck/index.html)-based testing
 -   New methods: `Pointer::split_front`, `Pointer::split_back`, `Pointer::parent`, `Pointer::strip_suffix`
+-   Implemented `Display` and `Debug` for `ParseError`
 
 ### Changed
 
 -   Debug implementation now preserves type information (e.g. prints `PathBuf("/foo/bar")` instead of `"/foo/bar"`) - `Display` remains the same
 -   Original `Pointer` type renamed to `PointerBuf`
 -   `Pointer::root` is now `PointerBuf::new`
--   `Pointer::new` is now `PointerBuf::from_tokens`
+-   `Pointer::new` is now `PointerBuf::from_tokens` (and takes an `IntoIterator` argument - arrays still work)
 -   `Pointer::union` is now `PointerBuf::intersection`
+-   `Token` type has been simplified and is now by default a borrowed type (use `Token::to_owned` or `Token::into_owned` to make it owned)
 
 ### Fixed
 
@@ -35,6 +37,7 @@ This is a breaking release including [#30](https://github.com/chanced/jsonptr/pu
 -   Removes optional dependencies of `url`, `fluent-uri` and `uniresid` as well
     as the `TryFrom` implementations for `fluent_uri::Uri<String>`, `url::Url`,
     `uniresid::AbsoluteUri`, and `uniresid::Uri`
+-   Several redundant or error-prone trait implementations were removed from `Token`
 
 ## [0.4.7] 2024-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This is a breaking release including [#30](https://github.com/chanced/jsonptr/pu
 -   Removes optional dependencies of `url`, `fluent-uri` and `uniresid` as well
     as the `TryFrom` implementations for `fluent_uri::Uri<String>`, `url::Url`,
     `uniresid::AbsoluteUri`, and `uniresid::Uri`
+-   Removed `Token::as_key` and `Token::as_str` - use `Token::decoded().as_ref()` to achieve the same effect
 -   Several redundant or error-prone trait implementations were removed from `Token`
 
 ## [0.4.7] 2024-03-18

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -1,18 +1,14 @@
 use crate::{PointerBuf, Token};
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use quickcheck::Arbitrary;
 
-impl Arbitrary for Token {
+impl Arbitrary for Token<'static> {
     fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        Self::new(String::arbitrary(g))
+        Self::from_raw(String::arbitrary(g))
     }
 
     fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-        Box::new(ToString::to_string(self).shrink().map(Self::new))
+        Box::new(self.decoded().into_owned().shrink().map(Self::from_raw))
     }
 }
 
@@ -23,7 +19,7 @@ impl Arbitrary for PointerBuf {
     }
 
     fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-        let tokens: Vec<_> = self.tokens().collect();
+        let tokens: Vec<_> = self.tokens().map(|t| t.into_owned()).collect();
         Box::new((0..self.count()).map(move |i| {
             let subset: Vec<_> = tokens
                 .iter()

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -4,11 +4,11 @@ use quickcheck::Arbitrary;
 
 impl Arbitrary for Token<'static> {
     fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-        Self::from_raw(String::arbitrary(g))
+        Self::new(String::arbitrary(g))
     }
 
     fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-        Box::new(self.decoded().into_owned().shrink().map(Self::from_raw))
+        Box::new(self.decoded().into_owned().shrink().map(Self::new))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -325,3 +325,23 @@ impl Display for ReplaceTokenError {
         )
     }
 }
+
+/// Represents that the string is not a valid token under RFC 6901.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidEncodingError {
+    offset: usize,
+}
+
+impl InvalidEncodingError {
+    pub(crate) fn new(offset: usize) -> Self {
+        Self { offset }
+    }
+
+    /// The byte offset where the first invalid character occurs.
+    ///
+    /// Note that this may be equal to the length of the string if the string
+    /// ends with an incomplete escaped sequence.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,9 @@
+use crate::{PointerBuf, Token};
 use alloc::{
     format,
     string::{FromUtf8Error, String, ToString},
     vec::Vec,
 };
-
-use crate::{PointerBuf, Token};
 use core::{
     // error::Error as StdError,
     fmt::{Debug, Display, Formatter},
@@ -107,7 +106,7 @@ pub struct UnresolvableError {
     pub pointer: PointerBuf,
     /// The leaf node, if applicable, which was expected to be either an
     /// `Object` or an `Array`.
-    pub leaf: Option<Token>,
+    pub leaf: Option<Token<'static>>,
 }
 
 #[cfg(feature = "std")]
@@ -117,7 +116,7 @@ impl UnresolvableError {
     /// Creates a new `UnresolvableError` with the given `Pointer`.
     pub fn new(pointer: PointerBuf) -> Self {
         let leaf = if pointer.count() >= 2 {
-            Some(pointer.get(pointer.count() - 2).unwrap())
+            Some(pointer.get(pointer.count() - 2).unwrap().into_owned())
         } else {
             None
         };
@@ -132,7 +131,7 @@ impl Display for UnresolvableError {
             "can not resolve \"{}\" due to {} being a scalar value",
             self.pointer,
             self.leaf
-                .as_deref()
+                .as_ref()
                 .map_or_else(|| "the root value".to_string(), |l| format!("\"{l}\""))
         )
     }
@@ -171,31 +170,27 @@ impl From<OutOfBoundsError> for IndexError {
 }
 
 /// ParseError represents an that an error occurred when parsing an index.
-#[derive(PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ParseError {
-    /// The source `ParseIntError`
-    pub source: ParseIntError,
-    /// The `Token` which was unable to be parsed as an index.
-    pub token: Token,
+    source: ParseIntError,
+}
+
+impl ParseError {
+    pub(crate) fn new(source: ParseIntError) -> Self {
+        Self { source }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
 }
 
 impl Display for ParseError {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.source)
-    }
-}
-impl Debug for ParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ParseError")
-            .field("source", &self.source)
-            .field("token", &self.token)
-            .finish()
-    }
-}
-#[cfg(feature = "std")]
-impl std::error::Error for ParseError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(&self.source)
     }
 }
 
@@ -207,9 +202,8 @@ pub struct OutOfBoundsError {
     pub len: usize,
     /// The index of the array that was out of bounds.
     pub index: usize,
-    /// The `Token` which was out of bounds.
-    pub token: Token,
 }
+
 #[cfg(feature = "std")]
 impl std::error::Error for OutOfBoundsError {}
 

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -346,7 +346,7 @@ impl Pointer {
                 }
                 Value::Object(v) => {
                     value = v
-                        .get(token.as_key())
+                        .get(token.decoded().as_ref())
                         .ok_or_else(|| Error::from(NotFoundError::new(partial_path(rem))))?;
                 }
             }
@@ -375,7 +375,7 @@ impl Pointer {
                 }
                 Value::Object(v) => {
                     value = v
-                        .get_mut(token.as_key())
+                        .get_mut(token.decoded().as_ref())
                         .ok_or_else(|| Error::from(NotFoundError::new(partial_path(rem))))?;
                 }
             }
@@ -456,7 +456,7 @@ impl Pointer {
                     let idx = last.as_index(children.len()).ok()?;
                     children.remove(idx).into()
                 }
-                Value::Object(children) => children.remove(last.as_key()),
+                Value::Object(children) => children.remove(last.decoded().as_ref()),
                 _ => None,
             })
     }
@@ -499,7 +499,7 @@ impl Pointer {
         if let Some((token, tail)) = self.split_front() {
             match dest {
                 Value::Null | Value::Number(_) | Value::String(_) | Value::Bool(_) => {
-                    match token.as_str() {
+                    match token.decoded().as_ref() {
                         "0" => {
                             // first element will be traversed when we recurse
                             *dest = alloc::vec![Value::Null].into();
@@ -678,7 +678,7 @@ impl PartialOrd<String> for Pointer {
 }
 
 impl<'a> IntoIterator for &'a Pointer {
-    type Item = Token;
+    type Item = Token<'a>;
     type IntoIter = Tokens<'a>;
     fn into_iter(self) -> Self::IntoIter {
         self.tokens()
@@ -711,15 +711,12 @@ impl PointerBuf {
     }
 
     /// Creates a new `PointerBuf` from a slice of non-encoded strings.
-    pub fn from_tokens<V, T>(tokens: V) -> Self
+    pub fn from_tokens<'a, T>(tokens: impl IntoIterator<Item = T>) -> Self
     where
-        V: AsRef<[T]>,
-        Token: for<'a> From<&'a T>,
+        T: Into<Token<'a>>,
     {
         let mut inner = String::new();
-        let tokens = tokens.as_ref();
-
-        for t in tokens.iter().map(Into::<Token>::into) {
+        for t in tokens.into_iter().map(|v| v.into()) {
             inner.push('/');
             inner.push_str(t.encoded());
         }
@@ -744,27 +741,29 @@ impl PointerBuf {
     }
 
     /// Removes and returns the last `Token` in the `Pointer` if it exists.
-    pub fn pop_back(&mut self) -> Option<Token> {
-        if let Some((front, back)) = self.0.rsplit_once('/') {
-            let back = Token::from_encoded(back);
-            self.0 = front.to_owned();
+    pub fn pop_back(&mut self) -> Option<Token<'static>> {
+        if let Some(idx) = self.0.rfind('/') {
+            let back = Token::new(self.0.split_off(idx + 1).into());
+            self.0.pop(); // remove trailing `/`
             Some(back)
         } else {
-            None // is root
+            None
         }
     }
 
     /// Removes and returns the first `Token` in the `Pointer` if it exists.
-    pub fn pop_front(&mut self) -> Option<Token> {
+    pub fn pop_front(&mut self) -> Option<Token<'static>> {
         (!self.is_root()).then(|| {
-            if let Some((front, back)) = self.0[1..].split_once('/') {
-                let front = Token::from_encoded(front);
-                self.0 = String::from("/") + back;
-                front
+            // if not root, must contain at least one `/`
+            if let Some(idx) = self.0[1..].find('/') {
+                let mut token = self.0.split_off(idx + 1);
+                core::mem::swap(&mut token, &mut self.0);
+                token.remove(0); // remove leading `/`
+                Token::new(token.into())
             } else {
-                let token = Token::from_encoded(&self.0[1..]);
-                self.0.truncate(0);
-                token
+                let mut token = core::mem::take(&mut self.0);
+                token.remove(0); // remove leading `/`
+                Token::new(token.into())
             }
         })
     }
@@ -772,7 +771,7 @@ impl PointerBuf {
     /// Merges two `Pointer`s by appending `other` onto `self`.
     pub fn append(&mut self, other: &PointerBuf) -> &PointerBuf {
         if self.is_root() {
-            self.0 = other.0.clone();
+            self.0.clone_from(&other.0);
         } else if !other.is_root() {
             self.0.push_str(&other.0);
         }
@@ -803,15 +802,16 @@ impl PointerBuf {
                 pointer: self.clone(),
             });
         }
-        let old = tokens.get(index).cloned();
+        let old = tokens.get(index).map(|t| t.as_owned());
         tokens[index] = token;
 
-        self.0 = String::from("/")
-            + &tokens
-                .iter()
-                .map(Token::encoded)
-                .collect::<Vec<_>>()
-                .join("/");
+        let mut buf = String::new();
+        for token in tokens {
+            buf.push('/');
+            buf.push_str(token.encoded());
+        }
+        self.0 = buf;
+
         Ok(old)
     }
 
@@ -861,7 +861,7 @@ impl Serialize for PointerBuf {
     }
 }
 
-impl From<Token> for PointerBuf {
+impl From<Token<'_>> for PointerBuf {
     fn from(t: Token) -> Self {
         PointerBuf::from_tokens([t])
     }
@@ -882,7 +882,7 @@ impl From<usize> for PointerBuf {
 }
 
 impl<'a> IntoIterator for &'a PointerBuf {
-    type Item = Token;
+    type Item = Token<'a>;
     type IntoIter = Tokens<'a>;
     fn into_iter(self) -> Self::IntoIter {
         self.tokens()
@@ -968,7 +968,7 @@ mod tests {
         let ptr = Pointer::from_static("/a~1b");
         assert_eq!(ptr.as_str(), "/a~1b");
         assert_eq!(data.get("a/b").unwrap(), 1);
-        assert_eq!(&ptr.first().unwrap(), "a/b");
+        assert_eq!(&ptr.first().unwrap().decoded(), "a/b");
         assert_eq!(data.resolve(ptr).unwrap(), &json!(1));
 
         // "/c%d"       2
@@ -1134,13 +1134,13 @@ mod tests {
             let input = ["", "", "", "foo", "", "bar", "baz", ""];
             for (idx, s) in input.iter().enumerate() {
                 assert_eq!(ptr.tokens().count(), idx);
-                ptr.push_back(s.into());
+                ptr.push_back((*s).into());
             }
             assert_eq!(ptr.tokens().count(), input.len());
             for (idx, s) in input.iter().enumerate() {
                 assert_eq!(ptr.tokens().count(), 8 - idx);
-                assert_eq!(ptr.front().unwrap().as_str(), *s);
-                assert_eq!(ptr.pop_front().unwrap().as_str(), *s);
+                assert_eq!(ptr.front().unwrap().decoded(), *s);
+                assert_eq!(ptr.pop_front().unwrap().decoded(), *s);
             }
             assert_eq!(ptr.tokens().count(), 0);
             assert!(ptr.front().is_none());
@@ -1477,13 +1477,13 @@ mod tests {
             let input = ["", "", "", "foo", "", "bar", "baz", ""];
             for (idx, s) in input.iter().enumerate() {
                 assert_eq!(ptr.tokens().count(), idx);
-                ptr.push_back(s.into());
+                ptr.push_back((*s).into());
             }
             assert_eq!(ptr.tokens().count(), input.len());
             for (idx, s) in input.iter().enumerate().rev() {
                 assert_eq!(ptr.tokens().count(), idx + 1);
-                assert_eq!(ptr.back().unwrap().as_str(), *s);
-                assert_eq!(ptr.pop_back().unwrap().as_str(), *s);
+                assert_eq!(ptr.back().unwrap().decoded(), *s);
+                assert_eq!(ptr.pop_back().unwrap().decoded(), *s);
             }
             assert_eq!(ptr.tokens().count(), 0);
             assert!(ptr.back().is_none());
@@ -1624,10 +1624,13 @@ mod tests {
     }
 
     #[quickcheck]
-    fn qc_from_tokens(tokens: Vec<Token>) -> bool {
+    fn qc_from_tokens(tokens: Vec<String>) -> bool {
         let buf = PointerBuf::from_tokens(&tokens);
         let reconstructed: Vec<_> = buf.tokens().collect();
-        tokens == reconstructed
+        reconstructed
+            .into_iter()
+            .zip(tokens)
+            .all(|(a, b)| a.decoded() == b)
     }
 
     #[quickcheck]

--- a/src/token.rs
+++ b/src/token.rs
@@ -74,7 +74,7 @@ impl<'a> Token<'a> {
         }
     }
 
-    /// Constructs a `Token` from an arbitray string.
+    /// Constructs a `Token` from an arbitrary string.
     ///
     /// If the string contains a `/` or a `~`, then it will be assumed not
     /// encoded, in which case this function will encode it, allocating a new
@@ -314,7 +314,7 @@ impl<'a> From<&Token<'a>> for Token<'a> {
 
 impl core::fmt::Display for Token<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", self.inner.as_ref())
+        write!(f, "{}", self.decoded())
     }
 }
 

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -9,7 +9,7 @@ pub struct Tokens<'a> {
 }
 
 impl<'a> Iterator for Tokens<'a> {
-    type Item = Token;
+    type Item = Token<'a>;
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(Token::from_encoded)
     }
@@ -35,6 +35,5 @@ mod tests {
         assert_eq!(Token::from_encoded("~0~1").encoded(), "~0~1");
         let t = Token::from_encoded("a~1b");
         assert_eq!(t.decoded(), "a/b");
-        assert_eq!(&t, "a/b")
     }
 }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -11,29 +11,11 @@ pub struct Tokens<'a> {
 impl<'a> Iterator for Tokens<'a> {
     type Item = Token<'a>;
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(Token::from_encoded)
+        self.inner.next().map(Token::from_encoded_unchecked)
     }
 }
 impl<'t> Tokens<'t> {
     pub(crate) fn new(inner: Split<'t, char>) -> Self {
         Self { inner }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_from() {
-        assert_eq!(Token::from("/").encoded(), "~1");
-        assert_eq!(Token::from("~/").encoded(), "~0~1");
-    }
-    #[test]
-    fn test_from_encoded() {
-        assert_eq!(Token::from_encoded("~1").encoded(), "~1");
-        assert_eq!(Token::from_encoded("~0~1").encoded(), "~0~1");
-        let t = Token::from_encoded("a~1b");
-        assert_eq!(t.decoded(), "a/b");
     }
 }


### PR DESCRIPTION
This includes surprisingly few API changes. The main breaks come from the fact `Token` holds a (potentially non-static) lifetime now. I also remove several trait implementations and some methods, in favor of making the distinction between the encoded and decoded representations more explicit.
