### PR TITLE
add repr transparent to `Pointer`

### DIFF
--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -97,6 +97,8 @@ const fn is_valid_ptr(value: &str) -> bool {
 /// assert_eq!(bar, "baz");
 /// ```
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+// See https://doc.rust-lang.org/src/std/path.rs.html#1985
+#[cfg_attr(not(doc), repr(transparent))]
 pub struct Pointer(str);
 
 impl core::fmt::Display for Pointer {


### PR DESCRIPTION
I missed this when first implementing the slice-like `Pointer` type. I _think_ the compiler will use the same layout as `str` regardless, but it's important to make sure. This assumption is needed for the unsafe code used in this type to be sound.