### PR TITLE
Adds fluid methods to `Pointer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+-   Adds fluid methods `with_trailing_token`, `with_leading_token`,
+    `with_appended` to `Pointer` for more ergonomic pointer construction.
+
+## [0.6.0] - 2024-08-06
+
 ### Fixed
 
 -   `Token::to_index` now fails if the token contains leading zeros, as mandated by the RFC.
@@ -21,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   README tweak.
 
-## [0.5.0] 
+## [0.5.0]
 
 This is a breaking release including:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
--   Adds fluid methods `with_trailing_token`, `with_leading_token`,
-    `with_appended` to `Pointer` for more ergonomic pointer construction.
+-   Adds fluid methods `with_trailing_token`, `with_leading_token`, `concat` to `Pointer`.
 
 ## [0.6.0] - 2024-08-06
 

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -437,12 +437,9 @@ impl Pointer {
     /// let foobar = ptr.with_trailing_token("bar");
     /// assert_eq!(foobar, "/foo/bar");
     /// ```
-    pub fn with_trailing_token<'t, T>(&self, token: T) -> PointerBuf
-    where
-        T: Into<Token<'t>>,
-    {
+    pub fn with_trailing_token<'t>(&self, token: impl Into<Token<'t>>) -> PointerBuf {
         let mut buf = self.to_buf();
-        buf.push_back(token);
+        buf.push_back(token.into());
         buf
     }
 
@@ -460,10 +457,7 @@ impl Pointer {
     /// let foobar = ptr.with_leading_token("foo");
     /// assert_eq!(foobar, "/foo/bar");
     /// ```
-    pub fn with_leading_token<'t, T>(&self, token: T) -> PointerBuf
-    where
-        T: Into<Token<'t>>,
-    {
+    pub fn with_leading_token<'t>(&self, token: impl Into<Token<'t>>) -> PointerBuf {
         let mut buf = self.to_buf();
         buf.push_front(token);
         buf
@@ -807,19 +801,13 @@ impl PointerBuf {
     }
 
     /// Pushes a `Token` onto the front of this `Pointer`.
-    pub fn push_front<'t, T>(&mut self, token: T)
-    where
-        T: Into<Token<'t>>,
-    {
+    pub fn push_front<'t>(&mut self, token: impl Into<Token<'t>>) {
         self.0.insert(0, '/');
         self.0.insert_str(1, token.into().encoded());
     }
 
     /// Pushes a `Token` onto the back of this `Pointer`.
-    pub fn push_back<'t, T>(&mut self, token: T)
-    where
-        T: Into<Token<'t>>,
-    {
+    pub fn push_back<'t>(&mut self, token: impl Into<Token<'t>>) {
         self.0.push('/');
         self.0.push_str(token.into().encoded());
     }
@@ -866,10 +854,11 @@ impl PointerBuf {
     ///
     /// ## Errors
     /// A [`ReplaceError`] is returned if the index is out of bounds.
-    pub fn replace<'t, T>(&mut self, index: usize, token: T) -> Result<Option<Token>, ReplaceError>
-    where
-        T: Into<Token<'t>>,
-    {
+    pub fn replace<'t>(
+        &mut self,
+        index: usize,
+        token: impl Into<Token<'t>>,
+    ) -> Result<Option<Token>, ReplaceError> {
         if self.is_root() {
             return Err(ReplaceError {
                 count: self.count(),

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -422,6 +422,53 @@ impl Pointer {
     pub fn components(&self) -> Components {
         self.into()
     }
+
+    /// Appends `token` onto `self` as a new [`Pointerbuf`].
+    ///
+    /// ## Example
+    /// ```
+    /// let ptr = jsonptr::Pointer::from_static("/foo");
+    /// let foobar = ptr.with_trailing_token("bar");
+    /// assert_eq!(foobar, "/foo/bar");
+    /// ```
+    pub fn with_trailing_token<'t, T>(&self, token: T) -> PointerBuf
+    where
+        T: Into<Token<'t>>,
+    {
+        let mut buf = self.to_buf();
+        buf.push_back(token);
+        buf
+    }
+
+    /// Prepends `token` onto `self` as a new `PointerBuf`.
+    ///
+    /// ## Example
+    /// ```
+    /// let ptr = jsonptr::Pointer::from_static("/bar");
+    /// let foobar = ptr.with_leading_token("foo");
+    /// assert_eq!(foobar, "/foo/bar");
+    /// ```
+    pub fn with_leading_token<'t, T>(&self, token: T) -> PointerBuf
+    where
+        T: Into<Token<'t>>,
+    {
+        let mut buf = self.to_buf();
+        buf.push_front(token);
+        buf
+    }
+
+    /// Appends the `Pointer` `other` onto `self` as a new `PointerBuf`.
+    ///
+    /// ```
+    /// let ptr = jsonptr::Pointer::from_static("/foo");
+    /// let barbaz = jsonptr::Pointer::from_static("/bar/baz");
+    /// assert_eq!(ptr.with_appended(&barbaz), "/foo/bar/baz");
+    /// ```
+    pub fn with_appended(&self, other: &Pointer) -> PointerBuf {
+        let mut buf = self.to_buf();
+        buf.append(other);
+        buf
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -423,9 +423,15 @@ impl Pointer {
         self.into()
     }
 
-    /// Appends `token` onto `self` as a new [`Pointerbuf`].
+    /// Creates an owned [`Pointerbuf`] like `self` but with `token` appended.
     ///
-    /// ## Example
+    /// See [`PointerBuf::push_back`] for more details.
+    ///
+    /// **Note**: this method allocates. If you find yourself calling it more
+    /// than once for a given pointer, consider using [`PointerBuf::push_back`]
+    /// instead.
+    ///
+    /// ## Examples
     /// ```
     /// let ptr = jsonptr::Pointer::from_static("/foo");
     /// let foobar = ptr.with_trailing_token("bar");
@@ -440,9 +446,15 @@ impl Pointer {
         buf
     }
 
-    /// Prepends `token` onto `self` as a new `PointerBuf`.
+    /// Creates an owned [`Pointerbuf`] like `self` but with `token` prepended.
     ///
-    /// ## Example
+    /// See [`PointerBuf::push_front`] for more details.
+    ///
+    /// **Note**: this method allocates. If you find yourself calling it more
+    /// than once for a given pointer, consider using [`PointerBuf::push_front`]
+    /// instead.
+    ///
+    /// ## Examples
     /// ```
     /// let ptr = jsonptr::Pointer::from_static("/bar");
     /// let foobar = ptr.with_leading_token("foo");
@@ -457,14 +469,22 @@ impl Pointer {
         buf
     }
 
-    /// Appends the `Pointer` `other` onto `self` as a new `PointerBuf`.
+    /// Creates an owned [`Pointerbuf`] like `self` but with `other` appended to
+    /// the end.
     ///
+    /// See [`PointerBuf::append`] for more details.
+    ///
+    /// **Note**: this method allocates. If you find yourself calling it more
+    /// than once for a given pointer, consider using [`PointerBuf::append`]
+    /// instead.
+    ///
+    /// ## Examples
     /// ```
     /// let ptr = jsonptr::Pointer::from_static("/foo");
     /// let barbaz = jsonptr::Pointer::from_static("/bar/baz");
-    /// assert_eq!(ptr.with_appended(&barbaz), "/foo/bar/baz");
+    /// assert_eq!(ptr.concat(&barbaz), "/foo/bar/baz");
     /// ```
-    pub fn with_appended(&self, other: &Pointer) -> PointerBuf {
+    pub fn concat(&self, other: &Pointer) -> PointerBuf {
         let mut buf = self.to_buf();
         buf.append(other);
         buf


### PR DESCRIPTION
solves #31 by adding fluid methods to `Pointer`:
- `with_leading_token` - prepends a token
- `with_trailing_token` - appends a token
- `with_appended` - appends a pointer