### PR TITLE
Refactor constructor safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+-   Adds unsafe associated methods `Pointer::new_unchecked` and `PointerBuf::new_unchecked` for
+    external zero-cost construction.
+
 ## [0.6.2] 2024-09-30
 
 ### Added

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -542,7 +542,7 @@ impl Pointer {
     ///
     /// ## Examples
     /// ```
-    /// let mut ptr = jsonptr::PointerBuf::root();
+    /// let mut ptr = jsonptr::PointerBuf::new();
     /// assert!(ptr.is_empty());
     ///
     /// ptr.push_back("foo");
@@ -861,10 +861,8 @@ impl PointerBuf {
     ///
     /// ## Errors
     /// Returns a [`ParseError`] if the string is not a valid JSON Pointer.
-    pub fn parse(s: impl Into<String>) -> Result<Self, ParseError> {
-        let s = s.into();
-        validate(&s)?;
-        Ok(Self(s))
+    pub fn parse<S: AsRef<str> + ?Sized>(s: &S) -> Result<Self, ParseError> {
+        Pointer::parse(&s).map(Pointer::to_buf)
     }
 
     /// Creates a new `PointerBuf` from a slice of non-encoded strings.
@@ -1509,7 +1507,7 @@ mod tests {
             assert_eq!(ptr, Pointer::root());
         }
         {
-            let mut ptr = PointerBuf::root();
+            let mut ptr = PointerBuf::new();
             assert_eq!(ptr.tokens().count(), 0);
             ptr.push_back("");
             assert_eq!(ptr.tokens().count(), 1);
@@ -1517,7 +1515,7 @@ mod tests {
             assert_eq!(ptr.tokens().count(), 0);
         }
         {
-            let mut ptr = PointerBuf::root();
+            let mut ptr = PointerBuf::new();
             let input = ["", "", "", "foo", "", "bar", "baz", ""];
             for (idx, &s) in input.iter().enumerate() {
                 assert_eq!(ptr.tokens().count(), idx);
@@ -1711,7 +1709,7 @@ mod tests {
     #[test]
     fn pop_back_works_with_empty_strings() {
         {
-            let mut ptr = PointerBuf::root();
+            let mut ptr = PointerBuf::new();
             ptr.push_back("");
             ptr.push_back("");
             ptr.push_back("bar");
@@ -1723,10 +1721,10 @@ mod tests {
             assert_eq!(ptr.tokens().count(), 1);
             ptr.pop_back();
             assert_eq!(ptr.tokens().count(), 0);
-            assert_eq!(ptr, PointerBuf::root());
+            assert_eq!(ptr, PointerBuf::new());
         }
         {
-            let mut ptr = PointerBuf::root();
+            let mut ptr = PointerBuf::new();
             assert_eq!(ptr.tokens().count(), 0);
             ptr.push_back("");
             assert_eq!(ptr.tokens().count(), 1);
@@ -1734,7 +1732,7 @@ mod tests {
             assert_eq!(ptr.tokens().count(), 0);
         }
         {
-            let mut ptr = PointerBuf::root();
+            let mut ptr = PointerBuf::new();
             let input = ["", "", "", "foo", "", "bar", "baz", ""];
             for (idx, &s) in input.iter().enumerate() {
                 assert_eq!(ptr.tokens().count(), idx);

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -55,10 +55,12 @@ impl Pointer {
     ///
     /// ## Safety
     /// The provided string must adhere to [RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901):
+    ///
     /// - The pointer must start with `'/'` (%x2F) unless empty
     /// - Tokens must be properly encoded:
     ///     - `'~'` (%x7E) must be escaped as `"~0"`
     ///     - `'/'` (%x2F) must be escaped as `"~1"`
+    ///
     /// For potentially fallible parsing, see [`Pointer::parse`].
     pub unsafe fn new_unchecked<S: AsRef<str> + ?Sized>(s: &S) -> &Self {
         &*(core::ptr::from_ref::<str>(s.as_ref()) as *const Self)

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -54,7 +54,12 @@ impl Pointer {
     /// This is a cost-free conversion.
     ///
     /// ## Safety
-    /// The provided string must adhere to RFC 6901.
+    /// The provided string must adhere to [RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901):
+    /// - The pointer must start with `'/'` (%x2F) unless empty
+    /// - Tokens must be properly encoded:
+    ///     - `'~'` (%x7E) must be escaped as `"~0"`
+    ///     - `'/'` (%x2F) must be escaped as `"~1"`
+    /// For potentially fallible parsing, see [`Pointer::parse`].
     pub unsafe fn new_unchecked<S: AsRef<str> + ?Sized>(s: &S) -> &Self {
         &*(core::ptr::from_ref::<str>(s.as_ref()) as *const Self)
     }

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -51,7 +51,7 @@ impl core::fmt::Display for Pointer {
 impl Pointer {
     /// Create a `Pointer` from a string that is known to be correctly encoded.
     ///
-    /// This is a zero-copy constructor.
+    /// This is a cost-free conversion.
     ///
     /// ## Safety
     /// The provided string must adhere to RFC 6901.
@@ -1300,6 +1300,20 @@ mod tests {
     #[should_panic = "invalid json pointer"]
     fn from_const_validates() {
         let _ = Pointer::from_static("foo/bar");
+    }
+
+    #[test]
+    fn root_is_alias_of_new_pathbuf() {
+        assert_eq!(PointerBuf::root(), PointerBuf::new());
+    }
+
+    #[test]
+    fn from_unchecked_pathbuf() {
+        let s = "/foo/bar/0";
+        assert_eq!(
+            unsafe { PointerBuf::new_unchecked(String::from(s)) },
+            PointerBuf::parse(s).unwrap()
+        );
     }
 
     #[test]

--- a/src/token.rs
+++ b/src/token.rs
@@ -42,6 +42,9 @@ impl<'a> Token<'a> {
     ///
     /// This is like [`Self::from_encoded`], except that no validation is
     /// performed on the input string.
+    ///
+    /// ## Safety
+    /// Input string must be RFC 6901 encoded.
     pub(crate) unsafe fn from_encoded_unchecked(inner: impl Into<Cow<'a, str>>) -> Self {
         Self {
             inner: inner.into(),

--- a/src/token.rs
+++ b/src/token.rs
@@ -42,7 +42,7 @@ impl<'a> Token<'a> {
     ///
     /// This is like [`Self::from_encoded`], except that no validation is
     /// performed on the input string.
-    pub(crate) fn from_encoded_unchecked(inner: impl Into<Cow<'a, str>>) -> Self {
+    pub(crate) unsafe fn from_encoded_unchecked(inner: impl Into<Cow<'a, str>>) -> Self {
         Self {
             inner: inner.into(),
         }
@@ -255,7 +255,8 @@ macro_rules! impl_from_num {
         $(
             impl From<$ty> for Token<'static> {
                 fn from(v: $ty) -> Self {
-                    Token::from_encoded_unchecked(v.to_string())
+                    // SAFETY: only used for integer types, which are always valid
+                    unsafe { Token::from_encoded_unchecked(v.to_string()) }
                 }
             }
         )*
@@ -312,7 +313,10 @@ pub struct Tokens<'a> {
 impl<'a> Iterator for Tokens<'a> {
     type Item = Token<'a>;
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(Token::from_encoded_unchecked)
+        self.inner
+            .next()
+            // SAFETY: source pointer is encoded
+            .map(|s| unsafe { Token::from_encoded_unchecked(s) })
     }
 }
 impl<'t> Tokens<'t> {
@@ -476,13 +480,12 @@ mod tests {
     fn tokens() {
         let pointer = Pointer::from_static("/a/b/c");
         let tokens: Vec<Token> = pointer.tokens().collect();
-        assert_eq!(
-            tokens,
+        assert_eq!(tokens, unsafe {
             vec![
                 Token::from_encoded_unchecked("a"),
                 Token::from_encoded_unchecked("b"),
-                Token::from_encoded_unchecked("c")
+                Token::from_encoded_unchecked("c"),
             ]
-        );
+        });
     }
 }


### PR DESCRIPTION
Although a lot more inconvenient for us, some of our functions have invariants that have to be held externally, so they should be `unsafe fn`. This also makes it justifiable to expose them publicly (as then users can opt-in for manual checking of the invariants).

### Notable changes:
- Expose `Pointer::new` as a public (but unsafe) constructor (now called `Pointer::new_unchecked`). This gives users a way to bypass validation if they're sure they've got a valid string. Akin to `String::from_utf8_unchecked` and family.
- Add `PointerBuf::new_unchecked` as a new unsafe constructor, to match `Pointer::new_unchecked`.
- Made `Token::from_encoded_unchecked` unsafe. This one I didn't make public because I don't see much use for it. We may revisit this later.