### PR TITLE
update signature of PathBuf::parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+-   Changed signature of `PathBuf::parse` to avoid requiring allocation.
+
 ## [0.6.2] 2024-09-30
 
 ### Added

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -810,8 +810,10 @@ impl PointerBuf {
     ///
     /// ## Errors
     /// Returns a [`ParseError`] if the string is not a valid JSON Pointer.
-    pub fn parse<S: AsRef<str> + ?Sized>(s: &S) -> Result<Self, ParseError> {
-        Pointer::parse(&s).map(Pointer::to_buf)
+    pub fn parse(s: impl Into<String>) -> Result<Self, ParseError> {
+        let s = s.into();
+        validate(&s)?;
+        Ok(Self(s))
     }
 
     /// Creates a new `PointerBuf` from a slice of non-encoded strings.


### PR DESCRIPTION
This is what it should've always been. It's technically a breaking change, but I think it's ok because most types that implement `AsRef<str>` would also implement `Into<String>`.