### PR TITLE
Stricter validation of RFC 6901 array indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Adds method `into_buf` for `Box<Pointer>` and `impl From<PathBuf> for Box<Pointer>`. 
 -   Adds unsafe associated methods `Pointer::new_unchecked` and `PointerBuf::new_unchecked` for
     external zero-cost construction.
+-   Adds new `ParseIndexError` variant to express the presence non-digit characters in the token.
 
 ### Changed
 
 -   Changed signature of `PathBuf::parse` to avoid requiring allocation.
 -   Bumps minimum Rust version to 1.79.
+
+### Fixed
+
+-   Make validation of array indices conform to RFC 6901 in the presence of non-digit characters.
 
 ## [0.6.2] 2024-09-30
 

--- a/src/assign.rs
+++ b/src/assign.rs
@@ -767,6 +767,16 @@ mod tests {
                 }),
                 expected_data: json!([]),
             },
+            Test {
+                ptr: "/+23",
+                data: json!([]),
+                assign: json!("foo"),
+                expected: Err(AssignError::FailedToParseIndex {
+                    offset: 0,
+                    source: ParseIndexError::InvalidCharacters("+".into()),
+                }),
+                expected_data: json!([]),
+            },
         ]);
     }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -36,9 +36,8 @@
 //! ```
 
 use crate::Token;
-use alloc::string::String;
+use alloc::{string::String, vec::Vec};
 use core::{fmt, num::ParseIntError, str::FromStr};
-use std::collections::BTreeSet;
 
 /// Represents an abstract index into an array.
 ///
@@ -174,7 +173,10 @@ impl FromStr for Index {
                 // this comes up with the `+` sign which is valid for
                 // representing a `usize` but not allowed in RFC 6901 array
                 // indices
-                let invalid: BTreeSet<_> = s.chars().filter(|c| !c.is_ascii_digit()).collect();
+                let mut invalid: Vec<_> = s.chars().filter(|c| !c.is_ascii_digit()).collect();
+                // remove duplicate characters
+                invalid.sort_unstable();
+                invalid.dedup();
                 Err(ParseIndexError::InvalidCharacters(
                     invalid.into_iter().collect(),
                 ))

--- a/src/index.rs
+++ b/src/index.rs
@@ -434,6 +434,11 @@ mod tests {
             ParseIndexError::LeadingZeros.to_string(),
             "token contained leading zeros, which are disallowed by RFC 6901"
         );
+        assert_eq!(
+            ParseIndexError::InvalidCharacters("+@".into()).to_string(),
+            "token contains non-digit character(s) '+@', \
+                which are disallowed by RFC 6901"
+        );
     }
 
     #[test]

--- a/src/index.rs
+++ b/src/index.rs
@@ -38,6 +38,7 @@
 use crate::Token;
 use alloc::string::String;
 use core::{fmt, num::ParseIntError, str::FromStr};
+use std::collections::BTreeSet;
 
 /// Represents an abstract index into an array.
 ///
@@ -173,8 +174,10 @@ impl FromStr for Index {
                 // this comes up with the `+` sign which is valid for
                 // representing a `usize` but not allowed in RFC 6901 array
                 // indices
-                let invalid: String = s.chars().filter(|c| !c.is_ascii_digit()).collect();
-                Err(ParseIndexError::InvalidCharacters(invalid))
+                let invalid: BTreeSet<_> = s.chars().filter(|c| !c.is_ascii_digit()).collect();
+                Err(ParseIndexError::InvalidCharacters(
+                    invalid.into_iter().collect(),
+                ))
             }
         }
     }


### PR DESCRIPTION
RFC 6901 is very strict about what it allows as an array index. Leading zeros are disallowed, and only digit characters are valid.

I had previously added a check for the leading zeros, but as it turns out that wasn't sufficient. Rust permits `+` as a prefix in a stringified `usize`, so we're currently more permissive than RFC 6901.

I think with this explicit check we finally reach exact parity with RFC 6901 in this aspect. `is_ascii_digit` is documented to check for the `U+0030 ‘0’ ..= U+0039 ‘9’.` range exactly, which is what we need.

This is a bug fix, though technically breaking.