### PR TITLE
Add `Token::is_next` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Adds method `into_buf` for `Box<Pointer>` and `impl From<PathBuf> for Box<Pointer>`. 
 -   Adds unsafe associated methods `Pointer::new_unchecked` and `PointerBuf::new_unchecked` for
     external zero-cost construction.
+-   Adds `Token::is_next` for checking if a token represents the `-` character.
 
 ### Changed
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -251,6 +251,13 @@ impl<'a> Token<'a> {
     pub fn to_index(&self) -> Result<Index, ParseIndexError> {
         self.try_into()
     }
+
+    /// Returns if the `Token` is `-`, which stands for the next array index.
+    ///
+    /// See also [`Self::to_index`].
+    pub fn is_next(&self) -> bool {
+        matches!(self.to_index(), Ok(Index::Next))
+    }
 }
 
 macro_rules! impl_from_num {
@@ -490,5 +497,17 @@ mod tests {
                 Token::from_encoded_unchecked("c"),
             ]
         });
+    }
+
+    #[test]
+    fn is_next() {
+        let token = Token::new("-");
+        assert!(token.is_next());
+        let token = Token::new("0");
+        assert!(!token.is_next());
+        let token = Token::new("a");
+        assert!(!token.is_next());
+        let token = Token::new("");
+        assert!(!token.is_next());
     }
 }


### PR DESCRIPTION
Small QoL addition.

Also open to naming it `is_next_idx` to avoid ambiguity if used in combination with `Pointer::tokens` (I don't think this is particularly confusing, but 🤷 ).