### PR TITLE
rename SlicePointer --> PointerIndex

### DIFF
--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -7,7 +7,7 @@ use alloc::{
     vec::Vec,
 };
 use core::{borrow::Borrow, cmp::Ordering, ops::Deref, str::FromStr};
-use slice::SlicePointer;
+use slice::PointerIndex;
 
 mod slice;
 
@@ -320,7 +320,7 @@ impl Pointer {
     /// ```
     pub fn get<'p, I>(&'p self, index: I) -> Option<I::Output>
     where
-        I: SlicePointer<'p>,
+        I: PointerIndex<'p>,
     {
         index.get(self)
     }

--- a/src/pointer/slice.rs
+++ b/src/pointer/slice.rs
@@ -2,13 +2,13 @@ use super::Pointer;
 use crate::Token;
 use core::ops::Bound;
 
-pub trait SlicePointer<'p>: private::Sealed {
+pub trait PointerIndex<'p>: private::Sealed {
     type Output: 'p;
 
     fn get(self, pointer: &'p Pointer) -> Option<Self::Output>;
 }
 
-impl<'p> SlicePointer<'p> for usize {
+impl<'p> PointerIndex<'p> for usize {
     type Output = Token<'p>;
 
     fn get(self, pointer: &'p Pointer) -> Option<Self::Output> {
@@ -16,7 +16,7 @@ impl<'p> SlicePointer<'p> for usize {
     }
 }
 
-impl<'p> SlicePointer<'p> for core::ops::Range<usize> {
+impl<'p> PointerIndex<'p> for core::ops::Range<usize> {
     type Output = &'p Pointer;
 
     fn get(self, pointer: &'p Pointer) -> Option<Self::Output> {
@@ -56,7 +56,7 @@ impl<'p> SlicePointer<'p> for core::ops::Range<usize> {
     }
 }
 
-impl<'p> SlicePointer<'p> for core::ops::RangeFrom<usize> {
+impl<'p> PointerIndex<'p> for core::ops::RangeFrom<usize> {
     type Output = &'p Pointer;
 
     fn get(self, pointer: &'p Pointer) -> Option<Self::Output> {
@@ -81,7 +81,7 @@ impl<'p> SlicePointer<'p> for core::ops::RangeFrom<usize> {
     }
 }
 
-impl<'p> SlicePointer<'p> for core::ops::RangeTo<usize> {
+impl<'p> PointerIndex<'p> for core::ops::RangeTo<usize> {
     type Output = &'p Pointer;
 
     fn get(self, pointer: &'p Pointer) -> Option<Self::Output> {
@@ -114,7 +114,7 @@ impl<'p> SlicePointer<'p> for core::ops::RangeTo<usize> {
     }
 }
 
-impl<'p> SlicePointer<'p> for core::ops::RangeFull {
+impl<'p> PointerIndex<'p> for core::ops::RangeFull {
     type Output = &'p Pointer;
 
     fn get(self, pointer: &'p Pointer) -> Option<Self::Output> {
@@ -122,7 +122,7 @@ impl<'p> SlicePointer<'p> for core::ops::RangeFull {
     }
 }
 
-impl<'p> SlicePointer<'p> for core::ops::RangeInclusive<usize> {
+impl<'p> PointerIndex<'p> for core::ops::RangeInclusive<usize> {
     type Output = &'p Pointer;
 
     fn get(self, pointer: &'p Pointer) -> Option<Self::Output> {
@@ -160,7 +160,7 @@ impl<'p> SlicePointer<'p> for core::ops::RangeInclusive<usize> {
     }
 }
 
-impl<'p> SlicePointer<'p> for core::ops::RangeToInclusive<usize> {
+impl<'p> PointerIndex<'p> for core::ops::RangeToInclusive<usize> {
     type Output = &'p Pointer;
 
     fn get(self, pointer: &'p Pointer) -> Option<Self::Output> {
@@ -190,7 +190,7 @@ impl<'p> SlicePointer<'p> for core::ops::RangeToInclusive<usize> {
     }
 }
 
-impl<'p> SlicePointer<'p> for (Bound<usize>, Bound<usize>) {
+impl<'p> PointerIndex<'p> for (Bound<usize>, Bound<usize>) {
     type Output = &'p Pointer;
 
     fn get(self, pointer: &'p Pointer) -> Option<Self::Output> {


### PR DESCRIPTION
Quick follow-up of #84, because my naming sense was drunk.

This is _technically_ breaking since the trait is nameable, but it's sealed and we haven't released yet, so let's pretend the original name just never happened.