### PR TITLE
Improve `ParseIndexError::InvalidCharacter` error

### DIFF
--- a/src/assign.rs
+++ b/src/assign.rs
@@ -552,10 +552,12 @@ mod toml {
 mod tests {
     use super::{Assign, AssignError};
     use crate::{
-        index::{OutOfBoundsError, ParseIndexError},
+        index::{InvalidCharacterError, OutOfBoundsError, ParseIndexError},
         Pointer,
     };
+    use alloc::vec;
     use core::fmt::{Debug, Display};
+    use serde_json::json;
 
     #[derive(Debug)]
     struct Test<V: Assign> {
@@ -604,10 +606,6 @@ mod tests {
     #[test]
     #[cfg(feature = "json")]
     fn assign_json() {
-        use alloc::vec;
-        use serde_json::json;
-
-        use crate::index::InvalidCharacterError;
         Test::all([
             Test {
                 ptr: "/foo",

--- a/src/assign.rs
+++ b/src/assign.rs
@@ -555,7 +555,6 @@ mod tests {
         index::{OutOfBoundsError, ParseIndexError},
         Pointer,
     };
-    use alloc::str::FromStr;
     use core::fmt::{Debug, Display};
 
     #[derive(Debug)]
@@ -607,6 +606,8 @@ mod tests {
     fn assign_json() {
         use alloc::vec;
         use serde_json::json;
+
+        use crate::index::InvalidCharacterError;
         Test::all([
             Test {
                 ptr: "/foo",
@@ -748,12 +749,15 @@ mod tests {
                 expected_data: json!(["bar"]),
             },
             Test {
-                ptr: "/a",
+                ptr: "/12a",
                 data: json!([]),
                 assign: json!("foo"),
                 expected: Err(AssignError::FailedToParseIndex {
                     offset: 0,
-                    source: ParseIndexError::InvalidInteger(usize::from_str("foo").unwrap_err()),
+                    source: ParseIndexError::InvalidCharacter(InvalidCharacterError {
+                        source: "12a".into(),
+                        offset: 2,
+                    }),
                 }),
                 expected_data: json!([]),
             },
@@ -773,7 +777,10 @@ mod tests {
                 assign: json!("foo"),
                 expected: Err(AssignError::FailedToParseIndex {
                     offset: 0,
-                    source: ParseIndexError::InvalidCharacter,
+                    source: ParseIndexError::InvalidCharacter(InvalidCharacterError {
+                        source: "+23".into(),
+                        offset: 0,
+                    }),
                 }),
                 expected_data: json!([]),
             },
@@ -791,6 +798,8 @@ mod tests {
     fn assign_toml() {
         use alloc::vec;
         use toml::{toml, Table, Value};
+
+        use crate::index::InvalidCharacterError;
         Test::all([
             Test {
                 data: Value::Table(toml::Table::new()),
@@ -925,7 +934,10 @@ mod tests {
                 assign: "foo".into(),
                 expected: Err(AssignError::FailedToParseIndex {
                     offset: 0,
-                    source: ParseIndexError::InvalidInteger(usize::from_str("foo").unwrap_err()),
+                    source: ParseIndexError::InvalidCharacter(InvalidCharacterError {
+                        source: "a".into(),
+                        offset: 0,
+                    }),
                 }),
                 expected_data: Value::Array(vec![]),
             },

--- a/src/assign.rs
+++ b/src/assign.rs
@@ -557,7 +557,6 @@ mod tests {
     };
     use alloc::vec;
     use core::fmt::{Debug, Display};
-    use serde_json::json;
 
     #[derive(Debug)]
     struct Test<V: Assign> {
@@ -606,6 +605,8 @@ mod tests {
     #[test]
     #[cfg(feature = "json")]
     fn assign_json() {
+        use serde_json::json;
+
         Test::all([
             Test {
                 ptr: "/foo",
@@ -794,10 +795,8 @@ mod tests {
     #[test]
     #[cfg(feature = "toml")]
     fn assign_toml() {
-        use alloc::vec;
         use toml::{toml, Table, Value};
 
-        use crate::index::InvalidCharacterError;
         Test::all([
             Test {
                 data: Value::Table(toml::Table::new()),

--- a/src/assign.rs
+++ b/src/assign.rs
@@ -773,7 +773,7 @@ mod tests {
                 assign: json!("foo"),
                 expected: Err(AssignError::FailedToParseIndex {
                     offset: 0,
-                    source: ParseIndexError::InvalidCharacters("+".into()),
+                    source: ParseIndexError::InvalidCharacter,
                 }),
                 expected_data: json!([]),
             },

--- a/src/index.rs
+++ b/src/index.rs
@@ -177,7 +177,7 @@ impl FromStr for Index {
                     // representing a `usize` but not allowed in RFC 6901 array
                     // indices
                     Err(ParseIndexError::InvalidCharacter(InvalidCharacterError {
-                        source: s.to_owned(),
+                        source: String::from(s),
                         offset,
                     }))
                 },


### PR DESCRIPTION
In #80 I introduced a new error variant to capture cases where the array index starts with `+` (which is valid for `usize` representations in Rust, but not valid for array indices per RFC 6901).

As I noted [here](https://github.com/chanced/jsonptr/pull/80#issuecomment-2427119055), keeping a collection of invalid characters in the error variant is overkill, since the accepted domain of `usize::parse` is _very_ unlikely to evolve, as that'd be a breaking change in `std`. According to [the docs](https://doc.rust-lang.org/std/primitive.usize.html#method.from_str_radix) `+` is the only accepted non-digit character, so we don't need to expect any others.

I'm not specialising the variant name for `+` though to leave some room for later adopting a different parser that has different domain (unlikely as that is) or in the off chance `std` does change this API. The error message changing isn't a hard break, if we ever need to update it in the future, so I'm keeping it more specific to make it more useful.