### PR TITLE
Refactor errors to include position, span (offset + len), and optional miette integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
+name = "higher-kinded-types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "561985554c8b8d4808605c90a5f1979cc6c31a5d20b78465cd59501233c6678e"
+dependencies = [
+ "never-say-never",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +86,7 @@ name = "jsonptr"
 version = "0.6.3"
 dependencies = [
  "miette",
+ "polonius-the-crab",
  "quickcheck",
  "quickcheck_macros",
  "serde",
@@ -133,6 +143,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.82",
+]
+
+[[package]]
+name = "never-say-never"
+version = "6.6.666"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
+
+[[package]]
+name = "polonius-the-crab"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d9b0ba45e2c294fcd0795bc51e45c12746758e9954bb1190f97603ec9a3e91"
+dependencies = [
+ "higher-kinded-types",
+ "never-say-never",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "env_logger"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,22 +45,22 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.2",
  "libc",
  "wasi",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -70,6 +76,7 @@ checksum = "d2f3e61cf687687b30c9e6ddf0fc36cf15f035e66d491e6da968fa49ffa9a378"
 name = "jsonptr"
 version = "0.6.3"
 dependencies = [
+ "miette",
  "quickcheck",
  "quickcheck_macros",
  "serde",
@@ -96,7 +103,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.2",
 ]
 
 [[package]]
@@ -106,10 +113,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.74"
+name = "miette"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
+checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "miette-derive",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
@@ -204,7 +234,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -220,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -240,13 +270,33 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.46"
+version = "2.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89456b690ff72fddcecf231caedbe615c59480c93358a93dfae7fc29e3ebbf0e"
+checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
 ]
 
 [[package]]
@@ -260,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.0"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c226a7bba6d859b63c92c4b4fe69c5b6b72d0cb897dbc8e6012298e6154cb56e"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -272,18 +322,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.20.0"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff63e60a958cefbb518ae1fd6566af80d9d4be430a33f3723dfc47d1d411d95"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
  "serde",
@@ -299,6 +349,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,9 +362,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "winnow"
-version = "0.5.0"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ rust-version = "1.79.0"
 version = "0.6.3"
 
 [dependencies]
-miette     = { version = "7.2.0", optional = true }
-serde      = { version = "1.0.203", optional = true, features = ["alloc"] }
-serde_json = { version = "1.0.119", optional = true, features = ["alloc"] }
-toml       = { version = "0.8", optional = true }
-
+miette            = { version = "7.2.0", optional = true }
+polonius-the-crab = { version = "0.4" }
+serde             = { version = "1.0.203", optional = true, features = ["alloc"] }
+serde_json        = { version = "1.0.119", optional = true, features = ["alloc"] }
+toml              = { version = "0.8", optional = true }
 [dev-dependencies]
 quickcheck        = "1.0.3"
 quickcheck_macros = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ syn = { version = "1.0.109", optional = true }
 
 [features]
 assign  = []
-default = ["std", "serde", "json", "resolve", "assign", "delete"]
+default = ["std", "serde", "json", "toml", "resolve", "assign", "delete"]
 delete  = ["resolve"]
 json    = ["dep:serde_json", "serde"]
 resolve = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.79.0"
 version = "0.6.3"
 
 [dependencies]
+miette     = { version = "7.2.0", optional = true }
 serde      = { version = "1.0.203", optional = true, features = ["alloc"] }
 serde_json = { version = "1.0.119", optional = true, features = ["alloc"] }
 toml       = { version = "0.8", optional = true }
@@ -30,10 +31,21 @@ quickcheck_macros = "1.0.0"
 syn = { version = "1.0.109", optional = true }
 
 [features]
+default = [
+  "miette",  # TODO: remove
+  "std",
+  "serde",
+  "json",
+  "toml",
+  "resolve",
+  "assign",
+  "delete",
+]
+
 assign  = []
-default = ["std", "serde", "json", "toml", "resolve", "assign", "delete"]
 delete  = ["resolve"]
 json    = ["dep:serde_json", "serde"]
+miette  = ["std", "dep:miette"]
 resolve = []
 std     = ["serde/std", "serde_json?/std"]
 toml    = ["dep:toml", "serde", "std"]

--- a/src/assign.rs
+++ b/src/assign.rs
@@ -133,27 +133,41 @@ pub trait Assign {
 ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 ╔══════════════════════════════════════════════════════════════════════════════╗
 ║                                                                              ║
-║                                 AssignError                                  ║
-║                                ¯¯¯¯¯¯¯¯¯¯¯¯¯                                 ║
+║                                    Error                                     ║
+║                                   ¯¯¯¯¯¯¯                                    ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 */
+
+// TODO: should AssignError be deprecated?
+/// Alias for [`Error`].
+///
+/// Possible error returned from [`Assign`] implementations for
+/// [`serde_json::Value`] and
+/// [`toml::Value`](https://docs.rs/toml/0.8.14/toml/index.html).
+pub type AssignError = Error;
 
 /// Possible error returned from [`Assign`] implementations for
 /// [`serde_json::Value`] and
 /// [`toml::Value`](https://docs.rs/toml/0.8.14/toml/index.html).
 #[derive(Debug, PartialEq, Eq)]
-pub enum AssignError {
-    /// A `Token` within the `Pointer` failed to be parsed as an array index.
+pub enum Error {
+    /// A [`Token`] within the [`Pointer`] failed to be parsed as an array index.
     FailedToParseIndex {
+        /// Position (index) of the token which failed to parse as an `Index`
+        position: usize,
         /// Offset of the partial pointer starting with the invalid index.
         offset: usize,
         /// The source [`ParseIndexError`]
         source: ParseIndexError,
     },
 
-    /// target array.
+    /// A [`Token`] within the [`Pointer`] contains an [`Index`] which is out of bounds.
+    ///
+    /// The current or resulting array's length is less than the index.
     OutOfBounds {
+        /// Position (index) of the token which failed to parse as an `Index`
+        position: usize,
         /// Offset of the partial pointer starting with the invalid index.
         offset: usize,
         /// The source [`OutOfBoundsError`]
@@ -161,19 +175,16 @@ pub enum AssignError {
     },
 }
 
-impl fmt::Display for AssignError {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::FailedToParseIndex { offset, .. } => {
-                write!(
-                    f,
-                    "assignment failed due to an invalid index at offset {offset}"
-                )
+            Self::FailedToParseIndex { .. } => {
+                write!(f, "assignment failed due to an invalid index")
             }
-            Self::OutOfBounds { offset, .. } => {
+            Self::OutOfBounds { .. } => {
                 write!(
                     f,
-                    "assignment failed due to index at offset {offset} being out of bounds"
+                    "assignment failed due to index an index being out of bounds"
                 )
             }
         }
@@ -181,7 +192,7 @@ impl fmt::Display for AssignError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for AssignError {
+impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::FailedToParseIndex { source, .. } => Some(source),
@@ -207,7 +218,7 @@ enum Assigned<'v, V> {
 
 #[cfg(feature = "json")]
 mod json {
-    use super::{Assign, AssignError, Assigned};
+    use super::{Assign, Assigned, Error};
     use crate::{Pointer, Token};
     use alloc::{
         string::{String, ToString},
@@ -235,7 +246,7 @@ mod json {
     }
     impl Assign for Value {
         type Value = Value;
-        type Error = AssignError;
+        type Error = Error;
         fn assign<V>(&mut self, ptr: &Pointer, value: V) -> Result<Option<Self::Value>, Self::Error>
         where
             V: Into<Self::Value>,
@@ -248,14 +259,15 @@ mod json {
         mut ptr: &Pointer,
         mut dest: &mut Value,
         mut value: Value,
-    ) -> Result<Option<Value>, AssignError> {
+    ) -> Result<Option<Value>, Error> {
         let mut offset = 0;
 
+        let mut position = 0;
         while let Some((token, tail)) = ptr.split_front() {
             let tok_len = token.encoded().len();
 
             let assigned = match dest {
-                Value::Array(array) => assign_array(token, tail, array, value, offset)?,
+                Value::Array(array) => assign_array(token, tail, array, value, position, offset)?,
                 Value::Object(obj) => assign_object(token, tail, obj, value),
                 _ => assign_scalar(ptr, dest, value),
             };
@@ -273,6 +285,7 @@ mod json {
                 }
             }
             offset += 1 + tok_len;
+            position += 1;
         }
 
         // Pointer is root, we can replace `dest` directly
@@ -285,14 +298,23 @@ mod json {
         remaining: &Pointer,
         array: &'v mut Vec<Value>,
         src: Value,
+        position: usize,
         offset: usize,
-    ) -> Result<Assigned<'v, Value>, AssignError> {
+    ) -> Result<Assigned<'v, Value>, Error> {
         // parsing the index
         let idx = token
             .to_index()
-            .map_err(|source| AssignError::FailedToParseIndex { offset, source })?
+            .map_err(|source| Error::FailedToParseIndex {
+                position,
+                offset,
+                source,
+            })?
             .for_len_incl(array.len())
-            .map_err(|source| AssignError::OutOfBounds { offset, source })?;
+            .map_err(|source| Error::OutOfBounds {
+                position,
+                offset,
+                source,
+            })?;
 
         debug_assert!(idx <= array.len());
 
@@ -381,7 +403,7 @@ mod json {
 
 #[cfg(feature = "toml")]
 mod toml {
-    use super::{Assign, AssignError, Assigned};
+    use super::{Assign, Assigned, Error};
     use crate::{Pointer, Token};
     use alloc::{string::String, vec, vec::Vec};
     use core::mem;
@@ -406,7 +428,7 @@ mod toml {
 
     impl Assign for Value {
         type Value = Value;
-        type Error = AssignError;
+        type Error = Error;
         fn assign<V>(&mut self, ptr: &Pointer, value: V) -> Result<Option<Self::Value>, Self::Error>
         where
             V: Into<Self::Value>,
@@ -419,14 +441,15 @@ mod toml {
         mut ptr: &Pointer,
         mut dest: &mut Value,
         mut value: Value,
-    ) -> Result<Option<Value>, AssignError> {
+    ) -> Result<Option<Value>, Error> {
         let mut offset = 0;
+        let mut position = 0;
 
         while let Some((token, tail)) = ptr.split_front() {
             let tok_len = token.encoded().len();
 
             let assigned = match dest {
-                Value::Array(array) => assign_array(token, tail, array, value, offset)?,
+                Value::Array(array) => assign_array(token, tail, array, value, position, offset)?,
                 Value::Table(tbl) => assign_object(token, tail, tbl, value),
                 _ => assign_scalar(ptr, dest, value),
             };
@@ -444,6 +467,7 @@ mod toml {
                 }
             }
             offset += 1 + tok_len;
+            position += 1;
         }
 
         // Pointer is root, we can replace `dest` directly
@@ -457,14 +481,23 @@ mod toml {
         remaining: &Pointer,
         array: &'v mut Vec<Value>,
         src: Value,
+        position: usize,
         offset: usize,
-    ) -> Result<Assigned<'v, Value>, AssignError> {
+    ) -> Result<Assigned<'v, Value>, Error> {
         // parsing the index
         let idx = token
             .to_index()
-            .map_err(|source| AssignError::FailedToParseIndex { offset, source })?
+            .map_err(|source| Error::FailedToParseIndex {
+                position,
+                offset,
+                source,
+            })?
             .for_len_incl(array.len())
-            .map_err(|source| AssignError::OutOfBounds { offset, source })?;
+            .map_err(|source| Error::OutOfBounds {
+                position,
+                offset,
+                source,
+            })?;
 
         debug_assert!(idx <= array.len());
 
@@ -550,7 +583,7 @@ mod toml {
 #[cfg(test)]
 #[allow(clippy::too_many_lines)]
 mod tests {
-    use super::{Assign, AssignError};
+    use super::{Assign, Error};
     use crate::{
         index::{OutOfBoundsError, ParseIndexError},
         Pointer,
@@ -574,9 +607,6 @@ mod tests {
         V::Error: Debug + PartialEq,
         Result<Option<V>, V::Error>: PartialEq<Result<Option<V::Value>, V::Error>>,
     {
-        fn all(tests: impl IntoIterator<Item = Test<V>>) {
-            tests.into_iter().enumerate().for_each(|(i, t)| t.run(i));
-        }
         fn run(self, i: usize) {
             let Test {
                 ptr,
@@ -607,7 +637,7 @@ mod tests {
     fn assign_json() {
         use alloc::vec;
         use serde_json::json;
-        Test::all([
+        [
             Test {
                 ptr: "/foo",
                 data: json!({}),
@@ -731,7 +761,8 @@ mod tests {
                 ptr: "/1",
                 data: json!([]),
                 assign: json!("foo"),
-                expected: Err(AssignError::OutOfBounds {
+                expected: Err(Error::OutOfBounds {
+                    position: 0,
                     offset: 0,
                     source: OutOfBoundsError {
                         index: 1,
@@ -751,7 +782,8 @@ mod tests {
                 ptr: "/a",
                 data: json!([]),
                 assign: json!("foo"),
-                expected: Err(AssignError::FailedToParseIndex {
+                expected: Err(Error::FailedToParseIndex {
+                    position: 0,
                     offset: 0,
                     source: ParseIndexError::InvalidInteger(usize::from_str("foo").unwrap_err()),
                 }),
@@ -761,7 +793,8 @@ mod tests {
                 ptr: "/002",
                 data: json!([]),
                 assign: json!("foo"),
-                expected: Err(AssignError::FailedToParseIndex {
+                expected: Err(Error::FailedToParseIndex {
+                    position: 0,
                     offset: 0,
                     source: ParseIndexError::LeadingZeros,
                 }),
@@ -771,13 +804,17 @@ mod tests {
                 ptr: "/+23",
                 data: json!([]),
                 assign: json!("foo"),
-                expected: Err(AssignError::FailedToParseIndex {
+                expected: Err(Error::FailedToParseIndex {
+                    position: 0,
                     offset: 0,
                     source: ParseIndexError::InvalidCharacters("+".into()),
                 }),
                 expected_data: json!([]),
             },
-        ]);
+        ]
+        .into_iter()
+        .enumerate()
+        .for_each(|(i, t)| t.run(i));
     }
 
     /*
@@ -791,7 +828,7 @@ mod tests {
     fn assign_toml() {
         use alloc::vec;
         use toml::{toml, Table, Value};
-        Test::all([
+        [
             Test {
                 data: Value::Table(toml::Table::new()),
                 ptr: "/foo",
@@ -910,7 +947,8 @@ mod tests {
                 data: Value::Array(vec![]),
                 ptr: "/1",
                 assign: "foo".into(),
-                expected: Err(AssignError::OutOfBounds {
+                expected: Err(Error::OutOfBounds {
+                    position: 0,
                     offset: 0,
                     source: OutOfBoundsError {
                         index: 1,
@@ -923,12 +961,16 @@ mod tests {
                 data: Value::Array(vec![]),
                 ptr: "/a",
                 assign: "foo".into(),
-                expected: Err(AssignError::FailedToParseIndex {
+                expected: Err(Error::FailedToParseIndex {
+                    position: 0,
                     offset: 0,
                     source: ParseIndexError::InvalidInteger(usize::from_str("foo").unwrap_err()),
                 }),
                 expected_data: Value::Array(vec![]),
             },
-        ]);
+        ]
+        .into_iter()
+        .enumerate()
+        .for_each(|(i, t)| t.run(i));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,205 @@
+use core::iter::once;
+
+use crate::Token;
+
+/// Data structures utilized in errors
+
+/// Represents a span of text within a JSON Pointer
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Span {
+    pub offset: usize,
+    pub len: usize,
+}
+
+impl Span {
+    pub fn for_token(token: &Token, offset: usize) -> Self {
+        Self {
+            offset,
+            len: token.encoded().len(),
+        }
+    }
+}
+
+/// An error that pertains to a specific span of text within a JSON Pointer
+#[derive(Debug, PartialEq, Eq)]
+pub struct Spanned<E> {
+    span: Span,
+    source: E,
+}
+
+impl<E> Spanned<E> {
+    pub const fn new(span: Span, source: E) -> Self {
+        Self { span, source }
+    }
+
+    pub const fn span(&self) -> Span {
+        self.span
+    }
+
+    pub const fn offset(&self) -> usize {
+        self.span.offset
+    }
+
+    pub const fn len(&self) -> usize {
+        self.span.len
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.span.len == 0
+    }
+
+    pub const fn source(&self) -> &E {
+        &self.source
+    }
+}
+
+impl<E: core::fmt::Display> core::fmt::Display for Spanned<E> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.source.fmt(f)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<E> std::error::Error for Spanned<E>
+where
+    E: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+#[cfg(feature = "miette")]
+impl<E> miette::Diagnostic for Spanned<E>
+where
+    E: 'static + miette::Diagnostic,
+{
+    fn code<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
+        self.source.code()
+    }
+
+    fn severity(&self) -> Option<miette::Severity> {
+        self.source.severity()
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
+        self.source.help()
+    }
+
+    fn url<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
+        self.source.url()
+    }
+
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        self.source.source_code()
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+        Some(Box::new(once(miette::LabeledSpan::new(
+            None,
+            self.offset(),
+            self.len(),
+        ))))
+    }
+
+    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn miette::Diagnostic> + 'a>> {
+        self.source.related()
+    }
+
+    fn diagnostic_source(&self) -> Option<&dyn miette::Diagnostic> {
+        self.source.diagnostic_source()
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Positioned<E> {
+    position: usize,
+    source: Spanned<E>,
+}
+
+impl<E> Positioned<E> {
+    pub const fn new(source: E, position: usize, span: Span) -> Self {
+        Self {
+            position,
+            source: Spanned::new(span, source),
+        }
+    }
+
+    pub const fn position(&self) -> usize {
+        self.position
+    }
+
+    pub const fn span(&self) -> Span {
+        self.source.span
+    }
+
+    pub const fn offset(&self) -> usize {
+        self.source.offset()
+    }
+
+    pub const fn len(&self) -> usize {
+        self.source.len()
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.source.is_empty()
+    }
+
+    pub const fn source(&self) -> &Spanned<E> {
+        &self.source
+    }
+}
+
+impl<E: core::fmt::Display> core::fmt::Display for Positioned<E> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.source.fmt(f)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<E> std::error::Error for Positioned<E>
+where
+    E: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+#[cfg(feature = "miette")]
+impl<E> miette::Diagnostic for Positioned<E>
+where
+    E: 'static + miette::Diagnostic,
+{
+    fn code<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
+        self.source.code()
+    }
+
+    fn severity(&self) -> Option<miette::Severity> {
+        self.source.severity()
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
+        self.source.help()
+    }
+
+    fn url<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
+        self.source.url()
+    }
+
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        self.source.source_code()
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+        self.source.labels()
+    }
+
+    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn miette::Diagnostic> + 'a>> {
+        self.source.related()
+    }
+
+    fn diagnostic_source(&self) -> Option<&dyn miette::Diagnostic> {
+        self.source.diagnostic_source()
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,291 +1,276 @@
-use core::{borrow::Borrow, iter::once};
-use std::{borrow::Cow, path::Display};
+// /// Data structures utilized in errors
 
-use serde_json::Value;
+// /// Represents a span of text within a JSON Pointer
+// #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+// pub struct Span {
+//     /// Offset in bytes
+//     pub offset: usize,
+//     /// Length in bytes
+//     pub len: usize,
+// }
 
-use crate::{Pointer, PointerBuf, Token};
+// impl Span {
+//     /// Creates a new span at the given `offset` and `len`
+//     pub const fn new(offset: usize, len: usize) -> Self {
+//         Self { offset, len }
+//     }
 
-/// Data structures utilized in errors
+//     /// Creates a new `Span` for a `Token` using the byte length of the token's
+//     /// encoded representation
+//     pub fn for_token(token: &Token, offset: usize) -> Self {
+//         Self {
+//             offset,
+//             len: token.encoded().len(),
+//         }
+//     }
 
-/// Represents a span of text within a JSON Pointer
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct Span {
-    pub offset: usize,
-    pub len: usize,
-}
+//     /// Creates an empty `Span`
+//     pub const fn empty() -> Self {
+//         Self { offset: 0, len: 0 }
+//     }
+// }
 
-impl Span {
-    pub const fn new(offset: usize, len: usize) -> Self {
-        Self { offset, len }
-    }
-    pub fn for_token(token: &Token, offset: usize) -> Self {
-        Self {
-            offset,
-            len: token.encoded().len(),
-        }
-    }
-    pub const fn empty() -> Self {
-        Self { offset: 0, len: 0 }
-    }
-}
+// /// An error wrapper which contains a [`Span`], offset and len of in bytes,
+// /// within a pointer or string.
+// #[derive(Debug, PartialEq, Eq)]
+// pub struct Spanned<E> {
+//     span: Span,
+//     source: E,
+// }
 
-/// An error that pertains to a specific span of text within a JSON Pointer
-#[derive(Debug, PartialEq, Eq)]
-pub struct Spanned<E> {
-    span: Span,
-    source: E,
-}
+// impl<E> Spanned<E> {
+//     /// Creates a new `Spanned` error with the given `span` and `source`
+//     pub const fn new(span: Span, source: E) -> Self {
+//         Self { span, source }
+//     }
 
-impl<E> Spanned<E> {
-    pub const fn new(span: Span, source: E) -> Self {
-        Self { span, source }
-    }
+//     /// Returns the span of the error
+//     pub const fn span(&self) -> Span {
+//         self.span
+//     }
 
-    pub const fn span(&self) -> Span {
-        self.span
-    }
+//     /// Returns the offset, in bytes, for where this error originated.
+//     ///
+//     /// Depending on the error, this may be a partial pointer, starting with the
+//     /// erroneous token, or the first byte of invalid formatting.
+//     pub const fn offset(&self) -> usize {
+//         self.span.offset
+//     }
 
-    pub const fn offset(&self) -> usize {
-        self.span.offset
-    }
+//     /// Returns the length (in bytes) of the error's subject.
+//     ///
+//     /// Depending on the error, this may be the length of the erroneous token,
+//     /// or the length of the invalid formatting.
+//     pub const fn len(&self) -> usize {
+//         self.span.len
+//     }
 
-    pub const fn len(&self) -> usize {
-        self.span.len
-    }
+//     /// Returns whether the span of the error's subject is empty.
+//     pub const fn is_empty(&self) -> bool {
+//         self.span.len == 0
+//     }
 
-    pub const fn is_empty(&self) -> bool {
-        self.span.len == 0
-    }
+//     /// Returns the source error within this `Spanned` error wrapper.
+//     pub const fn source(&self) -> &E {
+//         &self.source
+//     }
+// }
 
-    pub const fn source(&self) -> &E {
-        &self.source
-    }
-}
+// impl<E: core::fmt::Display> core::fmt::Display for Spanned<E> {
+//     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+//         self.source.fmt(f)
+//     }
+// }
 
-impl<E: core::fmt::Display> core::fmt::Display for Spanned<E> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.source.fmt(f)
-    }
-}
+// #[cfg(feature = "std")]
+// impl<E> std::error::Error for Spanned<E>
+// where
+//     E: std::error::Error + 'static,
+// {
+//     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+//         Some(&self.source)
+//     }
+// }
 
-#[cfg(feature = "std")]
-impl<E> std::error::Error for Spanned<E>
-where
-    E: std::error::Error + 'static,
-{
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        Some(&self.source)
-    }
-}
+// #[cfg(feature = "miette")]
+// impl<E> miette::Diagnostic for Spanned<E>
+// where
+//     E: 'static + miette::Diagnostic,
+// {
+//     fn code<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
+//         self.source.code()
+//     }
 
-#[cfg(feature = "miette")]
-impl<E> miette::Diagnostic for Spanned<E>
-where
-    E: 'static + miette::Diagnostic,
-{
-    fn code<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
-        self.source.code()
-    }
+//     fn severity(&self) -> Option<miette::Severity> {
+//         self.source.severity()
+//     }
 
-    fn severity(&self) -> Option<miette::Severity> {
-        self.source.severity()
-    }
+//     fn help<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
+//         self.source.help()
+//     }
 
-    fn help<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
-        self.source.help()
-    }
+//     fn url<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
+//         self.source.url()
+//     }
 
-    fn url<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
-        self.source.url()
-    }
+//     fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+//         self.source.source_code()
+//     }
 
-    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-        self.source.source_code()
-    }
+//     fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+//         Some(Box::new(once(miette::LabeledSpan::new(
+//             None,
+//             self.offset(),
+//             self.len(),
+//         ))))
+//     }
 
-    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-        Some(Box::new(once(miette::LabeledSpan::new(
-            None,
-            self.offset(),
-            self.len(),
-        ))))
-    }
+//     fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn miette::Diagnostic> + 'a>> {
+//         self.source.related()
+//     }
 
-    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn miette::Diagnostic> + 'a>> {
-        self.source.related()
-    }
+//     fn diagnostic_source(&self) -> Option<&dyn miette::Diagnostic> {
+//         self.source.diagnostic_source()
+//     }
+// }
 
-    fn diagnostic_source(&self) -> Option<&dyn miette::Diagnostic> {
-        self.source.diagnostic_source()
-    }
-}
+// #[derive(Debug, PartialEq, Eq)]
+// pub struct Positioned<E> {
+//     position: usize,
+//     source: Spanned<E>,
+// }
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct Positioned<E> {
-    position: usize,
-    source: Spanned<E>,
-}
+// impl<E> Positioned<E> {
+//     pub const fn new(source: E, position: usize, span: Span) -> Self {
+//         Self {
+//             position,
+//             source: Spanned::new(span, source),
+//         }
+//     }
 
-impl<E> Positioned<E> {
-    pub const fn new(source: E, position: usize, span: Span) -> Self {
-        Self {
-            position,
-            source: Spanned::new(span, source),
-        }
-    }
+//     pub const fn position(&self) -> usize {
+//         self.position
+//     }
 
-    pub const fn position(&self) -> usize {
-        self.position
-    }
+//     pub const fn span(&self) -> Span {
+//         self.source.span
+//     }
 
-    pub const fn span(&self) -> Span {
-        self.source.span
-    }
+//     pub const fn offset(&self) -> usize {
+//         self.source.offset()
+//     }
 
-    pub const fn offset(&self) -> usize {
-        self.source.offset()
-    }
+//     pub const fn len(&self) -> usize {
+//         self.source.len()
+//     }
 
-    pub const fn len(&self) -> usize {
-        self.source.len()
-    }
+//     pub const fn is_empty(&self) -> bool {
+//         self.source.is_empty()
+//     }
 
-    pub const fn is_empty(&self) -> bool {
-        self.source.is_empty()
-    }
+//     pub const fn source(&self) -> &Spanned<E> {
+//         &self.source
+//     }
+// }
 
-    pub const fn source(&self) -> &Spanned<E> {
-        &self.source
-    }
-}
+// impl<E: core::fmt::Display> core::fmt::Display for Positioned<E> {
+//     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+//         self.source.fmt(f)
+//     }
+// }
 
-impl<E: core::fmt::Display> core::fmt::Display for Positioned<E> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        self.source.fmt(f)
-    }
-}
+// #[cfg(feature = "std")]
+// impl<E> std::error::Error for Positioned<E>
+// where
+//     E: std::error::Error + 'static,
+// {
+//     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+//         Some(&self.source)
+//     }
+// }
 
-#[cfg(feature = "std")]
-impl<E> std::error::Error for Positioned<E>
-where
-    E: std::error::Error + 'static,
-{
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        Some(&self.source)
-    }
-}
+// #[cfg(feature = "miette")]
+// impl<E> miette::Diagnostic for Positioned<E>
+// where
+//     E: 'static + miette::Diagnostic,
+// {
+//     fn code<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
+//         self.source.code()
+//     }
 
-#[cfg(feature = "miette")]
-impl<E> miette::Diagnostic for Positioned<E>
-where
-    E: 'static + miette::Diagnostic,
-{
-    fn code<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
-        self.source.code()
-    }
+//     fn severity(&self) -> Option<miette::Severity> {
+//         self.source.severity()
+//     }
 
-    fn severity(&self) -> Option<miette::Severity> {
-        self.source.severity()
-    }
+//     fn help<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
+//         self.source.help()
+//     }
 
-    fn help<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
-        self.source.help()
-    }
+//     fn url<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
+//         self.source.url()
+//     }
 
-    fn url<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
-        self.source.url()
-    }
+//     fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+//         self.source.source_code()
+//     }
 
-    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-        self.source.source_code()
-    }
+//     fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+//         self.source.labels()
+//     }
 
-    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-        self.source.labels()
-    }
+//     fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn miette::Diagnostic> + 'a>> {
+//         self.source.related()
+//     }
 
-    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn miette::Diagnostic> + 'a>> {
-        self.source.related()
-    }
+//     fn diagnostic_source(&self) -> Option<&dyn miette::Diagnostic> {
+//         self.source.diagnostic_source()
+//     }
+// }
 
-    fn diagnostic_source(&self) -> Option<&dyn miette::Diagnostic> {
-        self.source.diagnostic_source()
-    }
-}
+// #[derive(Debug, Clone, PartialEq, Eq)]
+// pub enum Subject {
+//     String(String),
+//     PointerBuf(PointerBuf),
+// }
 
-#[derive(Debug, PartialEq, Eq)]
-pub enum Subject {
-    String(String),
-    PointerBuf(PointerBuf),
-}
+// impl From<String> for Subject {
+//     fn from(s: String) -> Self {
+//         Self::String(s)
+//     }
+// }
 
-impl From<String> for Subject {
-    fn from(s: String) -> Self {
-        Self::String(s)
-    }
-}
+// impl From<&Pointer> for Subject {
+//     fn from(p: &Pointer) -> Self {
+//         Self::PointerBuf(p.to_buf())
+//     }
+// }
+// impl From<&str> for Subject {
+//     fn from(s: &str) -> Self {
+//         Self::String(s.into())
+//     }
+// }
+// impl From<PointerBuf> for Subject {
+//     fn from(p: PointerBuf) -> Self {
+//         Self::PointerBuf(p)
+//     }
+// }
+// impl From<&mut PointerBuf> for Subject {
+//     fn from(p: &mut PointerBuf) -> Self {
+//         Self::PointerBuf(p.clone())
+//     }
+// }
 
-impl From<&Pointer> for Subject {
-    fn from(p: &Pointer) -> Self {
-        Self::PointerBuf(p.to_buf())
-    }
-}
-impl From<&str> for Subject {
-    fn from(s: &str) -> Self {
-        Self::String(s.into())
-    }
-}
-impl From<PointerBuf> for Subject {
-    fn from(p: PointerBuf) -> Self {
-        Self::PointerBuf(p)
-    }
-}
-impl From<&mut PointerBuf> for Subject {
-    fn from(p: &mut PointerBuf) -> Self {
-        Self::PointerBuf(p.clone())
-    }
-}
+// impl From<&PointerBuf> for Subject {
+//     fn from(p: &PointerBuf) -> Self {
+//         Self::PointerBuf(p.clone())
+//     }
+// }
 
-impl From<&PointerBuf> for Subject {
-    fn from(p: &PointerBuf) -> Self {
-        Self::PointerBuf(p.clone())
-    }
-}
-
-impl core::fmt::Display for Subject {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::String(s) => s.fmt(f),
-            Self::PointerBuf(p) => p.fmt(f),
-        }
-    }
-}
-
-pub struct Report<E> {
-    pub source: E,
-    pub subject: Subject,
-}
-impl<E> Report<E> {
-    pub fn new(source: E, subject: impl Into<Subject>) -> Self {
-        Self {
-            source,
-            subject: subject.into(),
-        }
-    }
-}
-
-pub trait ReportErr<T> {
-    type Reporter<'e, E>
-    where
-        Self: 'e;
-
-    // TODO: naming, alts: report, include_err_report, with_err_report, ???
-    fn report_err(&'_ self) -> Self::Reporter<'_, T>;
-}
-
-pub trait ReportErrMut<T> {
-    type Reporter<'e, E>
-    where
-        Self: 'e;
-    fn report_err(&'_ mut self) -> Self::Reporter<'_, T>;
-}
+// impl core::fmt::Display for Subject {
+//     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+//         match self {
+//             Self::String(s) => s.fmt(f),
+//             Self::PointerBuf(p) => p.fmt(f),
+//         }
+//     }
+// }

--- a/src/error.rs
+++ b/src/error.rs
@@ -283,7 +283,7 @@ pub trait ReportErr<T> {
     fn report_err(&'_ self) -> Self::Reporter<'_, T>;
 }
 
-pub trait MutReportErr<T> {
+pub trait ReportErrMut<T> {
     type Reporter<'e, E>
     where
         Self: 'e;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ mod pointer;
 pub use pointer::{NoLeadingBackslashError, ParseError, Pointer, PointerBuf, ReplaceError};
 
 mod token;
-pub use token::{InvalidEncodingError, Token, Tokens};
+pub use token::{EncodingError, Error as TokenError, Token, Tokens};
 
 pub mod index;
 
@@ -76,8 +76,6 @@ mod component;
 pub use component::{Component, Components};
 
 pub mod error;
-
-pub mod reporter;
 
 #[cfg(test)]
 mod arbitrary;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub mod resolve;
 pub use resolve::{Resolve, ResolveMut};
 
 mod pointer;
-pub use pointer::{ParseError, Pointer, PointerBuf};
+pub use pointer::{NoLeadingBackslashError, ParseError, Pointer, PointerBuf, ReplaceError};
 
 mod token;
 pub use token::{InvalidEncodingError, Token, Tokens};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,5 +75,7 @@ pub mod index;
 mod component;
 pub use component::{Component, Components};
 
+pub mod error;
+
 #[cfg(test)]
 mod arbitrary;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,5 +77,7 @@ pub use component::{Component, Components};
 
 pub mod error;
 
+pub mod reporter;
+
 #[cfg(test)]
 mod arbitrary;

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -1044,11 +1044,13 @@ impl<'p> BufReporter<'p> {
     where
         'p: 't,
     {
-        let result = self.ptr.replace(index, token);
-        result.map_err(|err| Report {
-            source: err,
-            source_code: Cow::Borrowed(self.ptr.as_ptr()),
-        })
+        match self.ptr.replace(index, token) {
+            Ok(res) => Ok(res),
+            Err(source) => Err(Report {
+                source,
+                source_code: Cow::Borrowed(&*self.ptr),
+            }),
+        }
     }
 }
 

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -1026,34 +1026,6 @@ impl PointerBuf {
     }
 }
 
-pub struct BufReporter<'p> {
-    ptr: &'p mut PointerBuf,
-}
-
-impl<'p> BufReporter<'p> {
-    /// Attempts to replace a `Token` by the index, returning the replaced
-    /// `Token` if it already exists. Returns `None` otherwise.
-    ///
-    /// ## Errors
-    /// A [`ReplaceError`] is returned if the index is out of bounds.
-    pub fn replace<'t>(
-        mut self,
-        index: usize,
-        token: impl Into<Token<'t>>,
-    ) -> Result<Option<Token<'t>>, Report<'p, ReplaceError, Pointer>>
-    where
-        'p: 't,
-    {
-        match self.ptr.replace(index, token) {
-            Ok(res) => Ok(res),
-            Err(source) => Err(Report {
-                source,
-                source_code: Cow::Borrowed(&*self.ptr),
-            }),
-        }
-    }
-}
-
 impl FromStr for PointerBuf {
     type Err = ParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -50,6 +50,16 @@ impl ReportErr<resolve::Error> for Pointer {
         }
     }
 }
+impl ReportErr<resolve::Error> for PointerBuf {
+    type Reporter<'e, E> = Immutable<'e, resolve::Error> where Self: 'e;
+
+    fn report_err(&'_ self) -> Self::Reporter<'_, resolve::Error> {
+        Immutable {
+            ptr: self,
+            marker: PhantomData,
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct Mutable<'p, E> {

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -1,0 +1,48 @@
+use core::marker::PhantomData;
+
+use polonius_the_crab::polonius;
+
+use crate::{error::Report, pointer::ReplaceError, PointerBuf, Token};
+
+#[derive(Debug)]
+pub struct Mutable<'p, E> {
+    ptr: &'p mut PointerBuf,
+    marker: PhantomData<fn() -> E>,
+}
+
+impl<'p> Mutable<'p, ReplaceError> {
+    /// Attempts to replace a `Token` by the index, returning the replaced
+    /// `Token` if it already exists. Returns `None` otherwise.
+    ///
+    /// ## Errors
+    /// A [`ReplaceError`] is returned if the index is out of bounds.
+    #[allow(clippy::missing_panics_doc)]
+    pub fn replace<'t>(
+        self,
+        index: usize,
+        token: impl Into<Token<'t>>,
+    ) -> Result<Option<Token<'t>>, Report<ReplaceError>>
+    where
+        'p: 't,
+    {
+        use polonius_the_crab::{polonius, ForLt, Placeholder, PoloniusResult};
+        type TokenRef = ForLt!(<'a> = Result<Option<Token<'a>>, ReplaceError>);
+        let ptr = self.ptr;
+        match polonius::<_, _, TokenRef>(ptr, |ptr| match ptr.replace(index, token) {
+            Ok(res) => PoloniusResult::Borrowing(Ok(res)),
+            Err(err) => PoloniusResult::Owned {
+                value: Err::<TokenRef, ReplaceError>(err),
+                input_borrow: Placeholder,
+            },
+        }) {
+            PoloniusResult::Borrowing(ok) => Ok(unsafe { ok.unwrap_unchecked() }),
+            PoloniusResult::Owned {
+                value,
+                input_borrow,
+            } => Err(Report::new(
+                unsafe { value.unwrap_err_unchecked() },
+                input_borrow.clone(),
+            )),
+        }
+    }
+}

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -40,7 +40,7 @@ impl<'p> Immutable<'p, resolve::Error> {
     }
 }
 
-impl ReportErr<resolve::Error> for &'_ Pointer {
+impl ReportErr<resolve::Error> for Pointer {
     type Reporter<'e, E> = Immutable<'e, resolve::Error> where Self: 'e;
 
     fn report_err(&'_ self) -> Self::Reporter<'_, resolve::Error> {

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -34,6 +34,7 @@
 //!
 //!
 use crate::{
+    error::Positioned,
     index::{OutOfBoundsError, ParseIndexError},
     Pointer, Token,
 };
@@ -121,14 +122,7 @@ pub enum Error {
     /// let ptr = Pointer::from_static("/foo/invalid");
     /// assert!(ptr.resolve(&data).unwrap_err().is_failed_to_parse_index());
     /// ```
-    FailedToParseIndex {
-        /// Position (index) of the token which failed to parse as an `Index`
-        position: usize,
-        /// Offset of the partial pointer starting with the invalid index.
-        offset: usize,
-        /// The source `ParseIndexError`
-        source: ParseIndexError,
-    },
+    FailedToParseIndex(Positioned<ParseIndexError>),
 
     /// A [`Token`] within the [`Pointer`] contains an [`Index`] which is out of
     /// bounds.

--- a/src/token.rs
+++ b/src/token.rs
@@ -378,7 +378,7 @@ impl std::error::Error for InvalidEncodingError {}
 
 #[cfg(test)]
 mod tests {
-    use crate::{assign::AssignError, index::OutOfBoundsError, Pointer};
+    use crate::Pointer;
 
     use super::*;
     use quickcheck_macros::quickcheck;
@@ -406,53 +406,6 @@ mod tests {
     fn new() {
         assert_eq!(Token::new("~1").encoded(), "~01");
         assert_eq!(Token::new("a/b").encoded(), "a~1b");
-    }
-
-    #[test]
-    fn assign_error_display() {
-        let err = AssignError::FailedToParseIndex {
-            offset: 3,
-            source: ParseIndexError::InvalidInteger("a".parse::<usize>().unwrap_err()),
-        };
-        assert_eq!(
-            err.to_string(),
-            "assignment failed due to an invalid index at offset 3"
-        );
-
-        let err = AssignError::OutOfBounds {
-            offset: 3,
-            source: OutOfBoundsError {
-                index: 3,
-                length: 2,
-            },
-        };
-
-        assert_eq!(
-            err.to_string(),
-            "assignment failed due to index at offset 3 being out of bounds"
-        );
-    }
-
-    #[test]
-    #[cfg(feature = "std")]
-    fn assign_error_source() {
-        use std::error::Error;
-        let err = AssignError::FailedToParseIndex {
-            offset: 3,
-            source: ParseIndexError::InvalidInteger("a".parse::<usize>().unwrap_err()),
-        };
-        assert!(err.source().is_some());
-        assert!(err.source().unwrap().is::<ParseIndexError>());
-
-        let err = AssignError::OutOfBounds {
-            offset: 3,
-            source: OutOfBoundsError {
-                index: 3,
-                length: 2,
-            },
-        };
-
-        assert!(err.source().unwrap().is::<OutOfBoundsError>());
     }
 
     #[test]


### PR DESCRIPTION
This pull request:
- Adds `Span` structure which contains `len` & `offset` 
- Adds `Spanned` error wrapper struct that contains a `Span` and a source error. It implements `miette::Diagnostic` by acting as a pass-through for all methods except `labels` (used to mark spans). For `labels`, it provides a blank (`None`) label with the span
- Adds `Positioned` error wrapper struct that contains a `Spanned` error and a position. It also implements `miette::Diagnostic` by deferring to `Spanned`
- Changes all errors to tuple variants, using either `Positioned` or `Spanned`, depending on context.


I'm just getting started with it so it will not compile right now. I should hopefully have it done today.