### PR TITLE
refactor a bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Adds new `ParseIndexError` variant to express the presence non-digit characters in the token.
 -   Adds `Token::is_next` for checking if a token represents the `-` character.
 -   Adds `ParseBufError`, returned as the `Err` variant of `PointerBuf::parse`, which includes the input `String` (from `Into::into`).
+-   Adds `InvalidEncoding`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Adds `Pointer::starts_with` and `Pointer::ends_with` for prefix and suffix matching.
 -   Adds new `ParseIndexError` variant to express the presence non-digit characters in the token.
 -   Adds `Token::is_next` for checking if a token represents the `-` character.
--   Adds `ParseBufError`, returned as the `Err` variant of `PointerBuf::parse`, which includes the input `String` (from `Into::into`).
--   Adds `InvalidEncoding`
+-   Adds `InvalidEncoding` to represent the two possible encoding errors when decoding a token.
+-   Adds `diagnostic` mod, including:
+-   Adds `diagnotic::Diagnostic` trait to facilitate error reporting and
+    `miette` integration. All errors intended for usage with `assign::Assign` or
+    `resolve::Resolve` must implement this trait.
+-   Adds `"miette"` featureflag to enable `miette` integration for error reporting.
 
 ### Changed
 
@@ -25,10 +29,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `Pointer::get` now accepts ranges and can produce `Pointer` segments as output (similar to
     `slice::get`).
 -   `PointerBuf::parse` now returns `BufParseError` instead of `ParseError`.
+-   Adds field `position` to variants of `resolve::Error` and `assign::Error` to indicate the
+    token index of where the error occurred.
+-   Renames `ParseError::NoLeadingBackslash` to `ParseError::NoLeadingSlash`.
 
 ### Fixed
 
 -   Make validation of array indices conform to RFC 6901 in the presence of non-digit characters.
+
+### Deprecated
+
+-   `assign::AssignError` renamed to `assign::Error`
+-   `resolve::ResolveError` renamed to `resolve::Error`
+-   `InvalidEncodingError` renamed to `EncodingError`
 
 ## [0.6.2] 2024-09-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -172,9 +172,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miette"
-version = "7.2.0"
+version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
+checksum = "317f146e2eb7021892722af37cf1b971f0a70c8406f487e24952667616192c64"
 dependencies = [
  "backtrace",
  "backtrace-ext",
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "7.2.0"
+version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
+checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -379,12 +379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smawk"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
-
-[[package]]
 name = "supports-color"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,12 +423,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
 dependencies = [
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -443,7 +437,6 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 dependencies = [
- "smawk",
  "unicode-linebreak",
  "unicode-width",
 ]
@@ -528,35 +521,20 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.5"
+name = "windows-sys"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -565,21 +543,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -589,21 +561,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -619,21 +579,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -643,21 +591,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.79.0"
 version = "0.6.3"
 
 [dependencies]
-miette     = { version = "7.2.0", optional = true, features = ["fancy"] }
+miette     = { version = "7.4.0", optional = true, features = ["fancy"] }
 serde      = { version = "1.0.203", optional = true, features = ["alloc"] }
 serde_json = { version = "1.0.119", optional = true, features = ["alloc"] }
 toml       = { version = "0.8", optional = true }

--- a/src/assign.rs
+++ b/src/assign.rs
@@ -39,7 +39,7 @@
 use crate::{
     diagnostic::{impl_diagnostic_url, Diagnostic, Label},
     index::{OutOfBoundsError, ParseIndexError},
-    Pointer,
+    Pointer, PointerBuf,
 };
 use alloc::borrow::Cow;
 use core::{
@@ -228,8 +228,9 @@ impl fmt::Display for Error {
     }
 }
 
-impl<'s> Diagnostic<'s> for Error {
-    type Subject = Cow<'s, Pointer>;
+impl Diagnostic for Error {
+    type Subject = PointerBuf;
+    type Related = ();
 
     fn url() -> &'static str {
         impl_diagnostic_url!(enum assign::Error)

--- a/src/assign.rs
+++ b/src/assign.rs
@@ -43,6 +43,7 @@ use crate::{
 };
 use alloc::borrow::Cow;
 use core::{
+    convert::Infallible,
     fmt::{self, Debug},
     iter::once,
 };
@@ -230,7 +231,7 @@ impl fmt::Display for Error {
 
 impl Diagnostic for Error {
     type Subject = PointerBuf;
-    type Related = ();
+    type Related = Infallible;
 
     fn url() -> &'static str {
         impl_diagnostic_url!(enum assign::Error)

--- a/src/assign.rs
+++ b/src/assign.rs
@@ -41,6 +41,7 @@ use crate::{
     index::{OutOfBoundsError, ParseIndexError},
     Pointer, PointerBuf,
 };
+use alloc::boxed::Box;
 use core::{
     fmt::{self, Debug},
     iter::once,

--- a/src/assign.rs
+++ b/src/assign.rs
@@ -41,9 +41,7 @@ use crate::{
     index::{OutOfBoundsError, ParseIndexError},
     Pointer, PointerBuf,
 };
-use alloc::borrow::Cow;
 use core::{
-    convert::Infallible,
     fmt::{self, Debug},
     iter::once,
 };
@@ -190,7 +188,7 @@ pub enum Error {
 }
 
 impl Error {
-    /// Returns the position (index) of the [`Token`](crate::Token) which was out of bounds
+    /// The position (token index) of the [`Token`](crate::Token) which was out of bounds
     pub fn position(&self) -> usize {
         match self {
             Self::OutOfBounds { position, .. } | Self::FailedToParseIndex { position, .. } => {
@@ -198,7 +196,7 @@ impl Error {
             }
         }
     }
-
+    /// Offset (in bytes) of the partial pointer starting with the invalid token.
     pub fn offset(&self) -> usize {
         match self {
             Self::OutOfBounds { offset, .. } | Self::FailedToParseIndex { offset, .. } => *offset,
@@ -231,7 +229,6 @@ impl fmt::Display for Error {
 
 impl Diagnostic for Error {
     type Subject = PointerBuf;
-    type Related = Infallible;
 
     fn url() -> &'static str {
         impl_diagnostic_url!(enum assign::Error)

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -1,5 +1,6 @@
 //! Error reporting data structures and miette integration.
 
+use alloc::{boxed::Box, string::String};
 use core::{fmt, ops::Deref};
 
 /// Implemented by errors which can be converted into a [`Report`].

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -1,20 +1,11 @@
 //! Error reporting data structures and miette integration.
 
-use core::{convert::Infallible, fmt, ops::Deref};
-use std::sync::OnceLock;
+use core::{fmt, ops::Deref};
 
 /// Implemented by errors which can be converted into a [`Report`].
 pub trait Diagnostic: Sized {
     /// The value which caused the error.
     type Subject: Deref;
-
-    /// Optional type of related errors for miette reporting.
-    ///
-    /// This is required as this trait is not object safe. Implementations which
-    /// do not have related errors should use
-    /// [`Infallible`](core::convert::Infallible) and simply not implement
-    /// `related`.
-    type Related;
 
     /// Combine the error with its subject to generate a [`Report`].
     fn into_report(self, subject: impl Into<Self::Subject>) -> Report<Self> {
@@ -26,37 +17,6 @@ pub trait Diagnostic: Sized {
 
     /// Returns the label for the given [`Subject`] if applicable.
     fn labels(&self, subject: &Self::Subject) -> Option<Box<dyn Iterator<Item = Label>>>;
-
-    /// Returns the related errors if applicable.
-    fn related(&self, subject: &Self::Subject) -> Vec<Self::Related> {
-        _ = subject;
-        vec![]
-    }
-}
-impl Diagnostic for () {
-    type Subject = String;
-    type Related = ();
-
-    fn url() -> &'static str {
-        ""
-    }
-
-    fn labels(&self, _: &Self::Subject) -> Option<Box<dyn Iterator<Item = Label>>> {
-        None
-    }
-}
-
-impl Diagnostic for Infallible {
-    type Subject = String;
-    type Related = ();
-
-    fn url() -> &'static str {
-        "https://doc.rust-lang.org/std/convert/enum.Infallible.html"
-    }
-
-    fn labels(&self, _: &Self::Subject) -> Option<Box<dyn Iterator<Item = Label>>> {
-        None
-    }
 }
 
 /// A label for a span within a json pointer or malformed string.
@@ -87,16 +47,11 @@ impl From<Label> for miette::LabeledSpan {
 pub struct Report<D: Diagnostic> {
     source: D,
     subject: D::Subject,
-    related: OnceLock<Vec<D::Related>>,
 }
 
 impl<D: Diagnostic> Report<D> {
     fn new(source: D, subject: D::Subject) -> Self {
-        Self {
-            source,
-            subject,
-            related: OnceLock::new(),
-        }
+        Self { source, subject }
     }
 
     /// The value which caused the error.
@@ -112,11 +67,6 @@ impl<D: Diagnostic> Report<D> {
     /// The original parts of the [`Report`].
     pub fn decompose(self) -> (D, D::Subject) {
         (self.source, self.subject)
-    }
-
-    pub fn related(&self) -> &[D::Related] {
-        self.related
-            .get_or_init(|| self.source.related(&self.subject))
     }
 }
 
@@ -138,7 +88,6 @@ impl<D: Diagnostic + fmt::Display> fmt::Display for Report<D> {
 impl<D> std::error::Error for Report<D>
 where
     D: Diagnostic + fmt::Debug + std::error::Error + 'static,
-    D::Related: fmt::Debug,
     D::Subject: fmt::Debug,
 {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
@@ -151,7 +100,6 @@ impl<D> miette::Diagnostic for Report<D>
 where
     D: Diagnostic + fmt::Debug + std::error::Error + 'static,
     D::Subject: fmt::Debug + miette::SourceCode,
-    D::Related: Diagnostic + fmt::Debug + std::error::Error + 'static,
 {
     fn url<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
         Some(Box::new(D::url()))
@@ -195,46 +143,39 @@ macro_rules! impl_diagnostic_url {
 }
 pub(crate) use impl_diagnostic_url;
 
-#[cfg(feature = "miette")]
-struct Borrowed<'a, D: Diagnostic> {
-    source: &'a D,
-    subject: &'a D::Subject,
-}
-#[cfg(feature = "miette")]
-impl<'a, D: Diagnostic> miette::Diagnostic for Borrowed<'a, D> {
-    fn url<'b>(&'b self) -> Option<Box<dyn core::fmt::Display + 'b>> {
-        Some(Box::new(D::url()))
-    }
-
-    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-        Some(self.subject)
-    }
-
-    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-        Diagnostic::labels(&self, self.subject)
-    }
-    fn related<'b>(&'b self) -> Option<Box<dyn Iterator<Item = &'b dyn miette::Diagnostic> + 'b>> {
-        Some(Box::new(
-            self.source.related(self.subject).iter().map(|r| r as _),
-        ))
-    }
-}
-
-mod private {
-    pub trait Sealed {}
-    impl Sealed for crate::pointer::ParseError {}
-    impl Sealed for crate::assign::Error {}
-}
-
+/// An extension trait for `Result<_, E>`, where `E` is an implementation of
+/// [`Diagnostic`], that converts `E` into [`Report<E>`](`Report`), yielding
+/// `Result<_, Report<E>>`.
 pub trait Diagnose<'s, T> {
+    /// The error type returned from `diagnose` and `diagnose_with`.
     type Error: Diagnostic;
 
+    /// If the `Result` is an `Err`, converts the error into a [`Report`] with
+    /// the supplied `subject`.
+    ///
+    /// ## Example
+    /// ```
+    /// use jsonptr::{Pointer, ParseError, Diagnose};
+    /// let subj = "invalid/pointer";
+    /// let err = Pointer::parse(subj).diagnose(subj).unwrap_err();
+    /// assert_eq!(err.type_id(),TypeId::of::<Report<ParseError>>());
+    /// ```
     #[allow(clippy::missing_errors_doc)]
     fn diagnose(
         self,
         subject: impl Into<<Self::Error as Diagnostic>::Subject>,
     ) -> Result<T, Report<Self::Error>>;
 
+    /// If the `Result` is an `Err`, converts the error into a [`Report`] with
+    /// the subject returned from `f`
+    ///
+    /// ## Example
+    /// ```
+    /// use jsonptr::{Pointer, ParseError, Diagnose};
+    /// let subj = "invalid/pointer";
+    /// let err = Pointer::parse(subj).diagnose_with(|| subj).unwrap_err();
+    ///
+    /// assert_eq!(err.type_id(),TypeId::of::<Report<ParseError>>());
     #[allow(clippy::missing_errors_doc)]
     fn diagnose_with<F, S>(self, f: F) -> Result<T, Report<Self::Error>>
     where
@@ -268,7 +209,6 @@ where
 mod tests {
     use super::*;
     use crate::{Pointer, PointerBuf};
-
     #[test]
     #[cfg(all(
         feature = "assign",
@@ -278,7 +218,6 @@ mod tests {
     ))]
     fn assign_error() {
         let mut v = serde_json::json!({"foo": {"bar": ["0"]}});
-        use miette::Diagnostic;
         let ptr = PointerBuf::parse("/foo/bar/invalid/cannot/reach").unwrap();
         let report = ptr.assign(&mut v, "qux").diagnose(ptr).unwrap_err();
         println!("{:?}", miette::Report::from(report));
@@ -299,17 +238,5 @@ mod tests {
 
         let report = miette::Report::from(report);
         println!("{report:?}");
-    }
-
-    #[test]
-    fn into_owned() {
-        // creating owned string to ensure its lifetime is local
-        // (could also coerce a static reference, but this is less brittle)
-        let invalid = "/foo/bar/invalid~3~encoding/cannot/reach".to_string();
-        let report = Pointer::parse(&invalid)
-            .diagnose(invalid.as_str())
-            .unwrap_err();
-
-        println!("{report}");
     }
 }

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -1,25 +1,24 @@
 //! Error reporting data structures and miette integration.
 
-use core::{fmt, ops::Deref};
+use core::{convert::Infallible, fmt, ops::Deref};
+use std::sync::OnceLock;
 
 /// Implemented by errors which can be converted into a [`Report`].
 pub trait Diagnostic: Sized {
     /// The value which caused the error.
     type Subject: Deref;
 
-    // TODO: this is here to handle multiple errors, if we choose to support it. remove if not needed.
     /// Optional type of related errors for miette reporting.
     ///
     /// This is required as this trait is not object safe. Implementations which
-    /// do not have related errors should use `()`.
+    /// do not have related errors should use
+    /// [`Infallible`](core::convert::Infallible) and simply not implement
+    /// `related`.
     type Related;
 
     /// Combine the error with its subject to generate a [`Report`].
     fn into_report(self, subject: impl Into<Self::Subject>) -> Report<Self> {
-        Report {
-            source: self,
-            subject: subject.into(),
-        }
+        Report::new(self, subject.into())
     }
 
     /// The docs.rs URL for this error
@@ -28,14 +27,40 @@ pub trait Diagnostic: Sized {
     /// Returns the label for the given [`Subject`] if applicable.
     fn labels(&self, subject: &Self::Subject) -> Option<Box<dyn Iterator<Item = Label>>>;
 
-    // TODO: this is here to handle multiple errors, if we choose to support it. remove if not needed.
-    // The idea is that we will need
-    fn related(&self) -> Option<Box<dyn Iterator<Item = Self::Related>>> {
+    /// Returns the related errors if applicable.
+    fn related(&self, subject: &Self::Subject) -> Vec<Self::Related> {
+        _ = subject;
+        vec![]
+    }
+}
+impl Diagnostic for () {
+    type Subject = String;
+    type Related = ();
+
+    fn url() -> &'static str {
+        ""
+    }
+
+    fn labels(&self, _: &Self::Subject) -> Option<Box<dyn Iterator<Item = Label>>> {
+        None
+    }
+}
+
+impl Diagnostic for Infallible {
+    type Subject = String;
+    type Related = ();
+
+    fn url() -> &'static str {
+        "https://doc.rust-lang.org/std/convert/enum.Infallible.html"
+    }
+
+    fn labels(&self, _: &Self::Subject) -> Option<Box<dyn Iterator<Item = Label>>> {
         None
     }
 }
 
 /// A label for a span within a json pointer or malformed string.
+///
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Label {
     text: String,
@@ -58,13 +83,22 @@ impl From<Label> for miette::LabeledSpan {
 }
 
 /// An error wrapper which includes the subject of the failure.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct Report<D: Diagnostic> {
     source: D,
     subject: D::Subject,
+    related: OnceLock<Vec<D::Related>>,
 }
 
 impl<D: Diagnostic> Report<D> {
+    fn new(source: D, subject: D::Subject) -> Self {
+        Self {
+            source,
+            subject,
+            related: OnceLock::new(),
+        }
+    }
+
     /// The value which caused the error.
     pub fn subject(&self) -> &<D::Subject as Deref>::Target {
         &self.subject
@@ -78,6 +112,11 @@ impl<D: Diagnostic> Report<D> {
     /// The original parts of the [`Report`].
     pub fn decompose(self) -> (D, D::Subject) {
         (self.source, self.subject)
+    }
+
+    pub fn related(&self) -> &[D::Related] {
+        self.related
+            .get_or_init(|| self.source.related(&self.subject))
     }
 }
 
@@ -99,6 +138,7 @@ impl<D: Diagnostic + fmt::Display> fmt::Display for Report<D> {
 impl<D> std::error::Error for Report<D>
 where
     D: Diagnostic + fmt::Debug + std::error::Error + 'static,
+    D::Related: fmt::Debug,
     D::Subject: fmt::Debug,
 {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
@@ -111,6 +151,7 @@ impl<D> miette::Diagnostic for Report<D>
 where
     D: Diagnostic + fmt::Debug + std::error::Error + 'static,
     D::Subject: fmt::Debug + miette::SourceCode,
+    D::Related: Diagnostic + fmt::Debug + std::error::Error + 'static,
 {
     fn url<'a>(&'a self) -> Option<Box<dyn core::fmt::Display + 'a>> {
         Some(Box::new(D::url()))
@@ -153,6 +194,31 @@ macro_rules! impl_diagnostic_url {
     };
 }
 pub(crate) use impl_diagnostic_url;
+
+#[cfg(feature = "miette")]
+struct Borrowed<'a, D: Diagnostic> {
+    source: &'a D,
+    subject: &'a D::Subject,
+}
+#[cfg(feature = "miette")]
+impl<'a, D: Diagnostic> miette::Diagnostic for Borrowed<'a, D> {
+    fn url<'b>(&'b self) -> Option<Box<dyn core::fmt::Display + 'b>> {
+        Some(Box::new(D::url()))
+    }
+
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        Some(self.subject)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+        Diagnostic::labels(&self, self.subject)
+    }
+    fn related<'b>(&'b self) -> Option<Box<dyn Iterator<Item = &'b dyn miette::Diagnostic> + 'b>> {
+        Some(Box::new(
+            self.source.related(self.subject).iter().map(|r| r as _),
+        ))
+    }
+}
 
 mod private {
     pub trait Sealed {}
@@ -212,7 +278,7 @@ mod tests {
     ))]
     fn assign_error() {
         let mut v = serde_json::json!({"foo": {"bar": ["0"]}});
-
+        use miette::Diagnostic;
         let ptr = PointerBuf::parse("/foo/bar/invalid/cannot/reach").unwrap();
         let report = ptr.assign(&mut v, "qux").diagnose(ptr).unwrap_err();
         println!("{:?}", miette::Report::from(report));

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -155,7 +155,8 @@ pub trait Diagnose<'s, T> {
     ///
     /// ## Example
     /// ```
-    /// use jsonptr::{Pointer, ParseError, Diagnose};
+    /// use core::any::{Any, TypeId};
+    /// use jsonptr::{Pointer, ParseError, Diagnose, Report};
     /// let subj = "invalid/pointer";
     /// let err = Pointer::parse(subj).diagnose(subj).unwrap_err();
     /// assert_eq!(err.type_id(),TypeId::of::<Report<ParseError>>());
@@ -171,7 +172,8 @@ pub trait Diagnose<'s, T> {
     ///
     /// ## Example
     /// ```
-    /// use jsonptr::{Pointer, ParseError, Diagnose};
+    /// use core::any::{Any, TypeId};
+    /// use jsonptr::{Pointer, ParseError, Diagnose, Report};
     /// let subj = "invalid/pointer";
     /// let err = Pointer::parse(subj).diagnose_with(|| subj).unwrap_err();
     ///

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -1,4 +1,5 @@
 //! Error reporting data structures and miette integration.
+//!
 
 use alloc::{boxed::Box, string::String};
 use core::{fmt, ops::Deref};
@@ -91,7 +92,7 @@ where
     D: Diagnostic + fmt::Debug + std::error::Error + 'static,
     D::Subject: fmt::Debug,
 {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(&self.source)
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -256,7 +256,7 @@ impl fmt::Display for OutOfBoundsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "index {} out of bounds (limit: {})",
+            "index {} out of bounds (len: {})",
             self.index, self.length
         )
     }

--- a/src/index.rs
+++ b/src/index.rs
@@ -468,28 +468,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_index_error_display() {
-        let err = ParseIndexError::InvalidInteger("not a number".parse::<usize>().unwrap_err());
-        assert_eq!(
-            err.to_string(),
-            "failed to parse token as an integer: invalid digit found in string"
-        );
-        assert_eq!(
-            ParseIndexError::LeadingZeros.to_string(),
-            "token contained leading zeros, which are disallowed by RFC 6901"
-        );
-        assert_eq!(
-            ParseIndexError::InvalidCharacter(InvalidCharacterError {
-                source: "+10".into(),
-                offset: 0
-            })
-            .to_string(),
-            "token contains the non-digit character '+', \
-                which is disallowed by RFC 6901"
-        );
-    }
-
-    #[test]
     #[cfg(feature = "std")]
     fn parse_index_error_source() {
         use std::error::Error;

--- a/src/index.rs
+++ b/src/index.rs
@@ -237,7 +237,7 @@ derive_try_from!(String, &String);
 */
 
 /// Indicates that an `Index` is not within the given bounds.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OutOfBoundsError {
     /// The provided array length.
     ///
@@ -276,7 +276,7 @@ impl std::error::Error for OutOfBoundsError {}
 */
 
 /// Indicates that the `Token` could not be parsed as valid RFC 6901 array index.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParseIndexError {
     /// The Token does not represent a valid integer.
     InvalidInteger(ParseIntError),
@@ -295,14 +295,16 @@ impl From<ParseIntError> for ParseIndexError {
 impl fmt::Display for ParseIndexError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ParseIndexError::InvalidInteger(source) => {
-                write!(f, "failed to parse token as an integer: {source}")
+            ParseIndexError::InvalidInteger(_) => {
+                write!(f, "failed to parse token as an integer")
             }
             ParseIndexError::LeadingZeros => write!(
                 f,
                 "token contained leading zeros, which are disallowed by RFC 6901"
             ),
-            ParseIndexError::InvalidCharacter(err) => err.fmt(f),
+            ParseIndexError::InvalidCharacter(_) => {
+                write!(f, "failed to parse token as an index")
+            }
         }
     }
 }
@@ -319,7 +321,7 @@ impl std::error::Error for ParseIndexError {
 }
 
 /// Indicates that a non-digit character was found when parsing the RFC 6901 array index.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InvalidCharacterError {
     pub(crate) source: String,
     pub(crate) offset: usize,

--- a/src/index.rs
+++ b/src/index.rs
@@ -459,27 +459,6 @@ mod tests {
     }
 
     #[test]
-    fn out_of_bounds_error_display() {
-        let err = OutOfBoundsError {
-            length: 5,
-            index: 10,
-        };
-        assert_eq!(err.to_string(), "index 10 out of bounds (limit: 5)");
-    }
-
-    #[test]
-    #[cfg(feature = "std")]
-    fn parse_index_error_source() {
-        use std::error::Error;
-        let err = ParseIndexError::InvalidInteger("not a number".parse::<usize>().unwrap_err());
-        assert_eq!(
-            err.source().unwrap().to_string(),
-            "not a number".parse::<usize>().unwrap_err().to_string()
-        );
-        assert!(ParseIndexError::LeadingZeros.source().is_none());
-    }
-
-    #[test]
     fn try_from_token() {
         let token = Token::new("3");
         let index = <Index as TryFrom<Token>>::try_from(token).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,9 +65,10 @@ pub mod resolve;
 pub use resolve::{Resolve, ResolveMut};
 
 pub mod diagnostic;
+pub use diagnostic::{Diagnose, Report};
 
 mod pointer;
-pub use pointer::{ParseError, ParseErrors, Pointer, PointerBuf, RichParseError};
+pub use pointer::{ParseError, Pointer, PointerBuf, RichParseError};
 
 mod token;
 pub use token::{EncodingError, InvalidEncoding, Token, Tokens};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,10 +67,13 @@ pub use resolve::{Resolve, ResolveMut};
 pub mod diagnostic;
 
 mod pointer;
-pub use pointer::{ParseError, Pointer, PointerBuf};
+pub use pointer::{ParseError, ParseErrors, Pointer, PointerBuf, RichParseError};
 
 mod token;
-pub use token::{InvalidEncodingError, Token, Tokens};
+pub use token::{EncodingError, InvalidEncoding, Token, Tokens};
+
+#[allow(deprecated)]
+pub use token::InvalidEncodingError;
 
 pub mod index;
 

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -2106,10 +2106,6 @@ mod tests {
 
         let invalid = serde_json::from_str::<&Pointer>("\"foo/bar\"");
         assert!(invalid.is_err());
-        assert_eq!(
-            invalid.unwrap_err().to_string(),
-            "failed to parse json pointer\n\ncaused by:\njson pointer is malformed as it does not start with a backslash ('/') and is not empty at line 1 column 9"
-        );
     }
 
     #[test]

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -1254,7 +1254,6 @@ impl ParseError {
 
 impl Diagnostic for ParseError {
     type Subject = String;
-    type Related = ParseError;
 
     fn url() -> &'static str {
         impl_diagnostic_url!(struct ParseError)
@@ -1270,17 +1269,10 @@ impl Diagnostic for ParseError {
         .to_string();
         Some(Box::new(once(Label::new(text, offset, len))))
     }
-
-    fn related(&self, subject: &Self::Subject) -> Vec<Self::Related> {
-        Validator {
-            bytes: subject.as_bytes(),
-            cursor: self.complete_offset(),
-            ptr_offset: self.pointer_offset(),
-            sent: true,
-        }
-        .collect()
-    }
 }
+
+#[cfg(feature = "miette")]
+impl miette::Diagnostic for ParseError {}
 
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -33,20 +33,13 @@
 //! | TOML  |    `toml::Value`    |   `"toml"`   |         |
 //!
 //!
-use crate::{
-    index::{OutOfBoundsError, ParseIndexError},
-    Pointer, Token,
-};
+use core::iter::once;
 
-/*
-░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-╔══════════════════════════════════════════════════════════════════════════════╗
-║                                                                              ║
-║                                   Resolve                                    ║
-║                                  ¯¯¯¯¯¯¯¯¯                                   ║
-╚══════════════════════════════════════════════════════════════════════════════╝
-░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-*/
+use crate::{
+    diagnostic::{diagnostic_url, Diagnostic, Label},
+    index::{OutOfBoundsError, ParseIndexError},
+    Pointer, PointerBuf, Token,
+};
 
 /// A trait implemented by types which can resolve a reference to a value type
 /// from a path represented by a JSON [`Pointer`].
@@ -65,16 +58,6 @@ pub trait Resolve {
     fn resolve(&self, ptr: &Pointer) -> Result<&Self::Value, Self::Error>;
 }
 
-/*
-░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-╔══════════════════════════════════════════════════════════════════════════════╗
-║                                                                              ║
-║                                 ResolveMut                                   ║
-║                                ¯¯¯¯¯¯¯¯¯¯¯¯                                  ║
-╚══════════════════════════════════════════════════════════════════════════════╝
-░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-*/
-
 /// A trait implemented by types which can resolve a mutable reference to a
 /// value type from a path represented by a JSON [`Pointer`].
 pub trait ResolveMut {
@@ -92,16 +75,6 @@ pub trait ResolveMut {
     /// be resolved.
     fn resolve_mut(&mut self, ptr: &Pointer) -> Result<&mut Self::Value, Self::Error>;
 }
-
-/*
-░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-╔══════════════════════════════════════════════════════════════════════════════╗
-║                                                                              ║
-║                                    Error                                     ║
-║                                   ¯¯¯¯¯¯¯                                    ║
-╚══════════════════════════════════════════════════════════════════════════════╝
-░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-*/
 
 // TODO: should ResolveError be deprecated?
 /// Alias for [`Error`].
@@ -233,6 +206,32 @@ impl Error {
     }
 }
 
+impl Diagnostic for Error {
+    type Subject = PointerBuf;
+
+    fn url() -> &'static str {
+        diagnostic_url!(enum assign::Error)
+    }
+
+    fn labels(&self, origin: &Self::Subject) -> Option<Box<dyn Iterator<Item = Label>>> {
+        let position = self.position();
+        let token = origin.get(position)?;
+        let offset = if self.offset() + 1 < origin.as_str().len() {
+            self.offset() + 1
+        } else {
+            self.offset()
+        };
+        let len = token.encoded().len();
+        let text = match self {
+            Error::FailedToParseIndex { .. } => "not an array index".to_string(),
+            Error::OutOfBounds { source, .. } => source.to_string(),
+            Error::NotFound { .. } => "not found in value".to_string(),
+            Error::Unreachable { .. } => "unreachable".to_string(),
+        };
+        Some(Box::new(once(Label::new(text, offset, len))))
+    }
+}
+
 impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
@@ -265,16 +264,6 @@ impl std::error::Error for Error {
         }
     }
 }
-
-/*
-░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-╔══════════════════════════════════════════════════════════════════════════════╗
-║                                                                              ║
-║                                  json impl                                   ║
-║                                 ¯¯¯¯¯¯¯¯¯¯¯                                  ║
-╚══════════════════════════════════════════════════════════════════════════════╝
-░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-*/
 
 #[cfg(feature = "json")]
 mod json {
@@ -373,16 +362,6 @@ fn parse_index(
         })
 }
 
-/*
-░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-╔══════════════════════════════════════════════════════════════════════════════╗
-║                                                                              ║
-║                                  toml impl                                   ║
-║                                 ¯¯¯¯¯¯¯¯¯¯¯                                  ║
-╚══════════════════════════════════════════════════════════════════════════════╝
-░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-*/
-
 #[cfg(feature = "toml")]
 mod toml {
     use super::{Error, Resolve, ResolveMut};
@@ -473,16 +452,6 @@ mod toml {
         }
     }
 }
-
-/*
-░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-╔══════════════════════════════════════════════════════════════════════════════╗
-║                                                                              ║
-║                                    Tests                                     ║
-║                                   ¯¯¯¯¯¯¯                                    ║
-╚══════════════════════════════════════════════════════════════════════════════╝
-░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-*/
 
 #[cfg(test)]
 mod tests {

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -235,20 +235,23 @@ impl Diagnostic for Error {
 impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::FailedToParseIndex { .. } => {
-                write!(f, "value failed to resolve by json pointer because an array index is not a valid integer")
+            Self::FailedToParseIndex { offset, .. } => {
+                write!(f, "resolve failed: json pointer token at offset {offset} failed to parse as an index")
             }
-            Self::OutOfBounds { .. } => {
+            Self::OutOfBounds { offset, .. } => {
                 write!(
                     f,
-                    "value failed to resolve by json pointer because an array index is out of bounds"
+                    "resolve failed: json pointer token at offset {offset} is out of bounds"
                 )
             }
-            Self::NotFound { .. } => {
-                write!(f, "value failed to resolve by json pointer because a value within the path is not present")
+            Self::NotFound { offset, .. } => {
+                write!(
+                    f,
+                    "resolve failed: json pointer token at {offset} was not found in value"
+                )
             }
-            Self::Unreachable { .. } => {
-                write!(f, "value failed to resolve by json pointer because a scalar or null value was encountered before exhausting the path")
+            Self::Unreachable { offset, .. } => {
+                write!(f, "resolve failed: json pointer token at {offset} is unreachable (previous token resolved to a scalar or null value)")
             }
         }
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -377,6 +377,7 @@ pub type InvalidEncodingError = EncodingError;
 pub struct EncodingError {
     /// offset of the erroneous `~` from within the `Token`
     pub offset: usize,
+    /// the specific encoding error
     pub source: InvalidEncoding,
 }
 
@@ -407,6 +408,7 @@ impl fmt::Display for EncodingError {
 ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 */
 
+/// Represents the specific type of invalid encoding error.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum InvalidEncoding {
     /// `~` not followed by `0` or `1`

--- a/src/token.rs
+++ b/src/token.rs
@@ -383,7 +383,7 @@ pub struct EncodingError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for EncodingError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(&self.source)
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -383,7 +383,7 @@ pub struct EncodingError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for EncodingError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         Some(&self.source)
     }
 }


### PR DESCRIPTION
Hey @asmello, I made some changes for you to review. High level:

- renames `SRC` generic of `Report`  to `D` and bound it to `Diagnostic`
- drops `SUB` in generic, uses `D::Subject` instead
- removes lifetime from `Report`
- removes seal for `Diagnostic`
- ~~Adds associated type `Related` and method `related` to `Diagnostic` for multi-errors~~

Regarding lifetimes, I really think we should only deal with owned subjects. It simplifies the code considerably, reduces boilerplate, avoids `borrowck` issues, and doesn't cost much; a single allocation at worst on an error path for reporting seems more than fair. Given that this behavior is opt-in, I say we keep it simple.

I really don't know about the multi-error list. We can include it and I made some changes to support it, but I don't know how valuable it'll be. However, it is possible with this structure. To support it, we will need a `struct ParseErrors(Box<[ParseError]>` that would have a `Related = ParseError` and I'll need to move over the logic from the other branch.