### PR TITLE
add helix editor configuration

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,0 +1,2 @@
+[language-server.rust-analyzer]
+config.cargo.features = "all"


### PR DESCRIPTION
I think anyone using Helix + rust-analyzer will want this set, otherwise clippy thinks there's a lot of unused code.