### PR TITLE
seal the `Diagnose` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+-   Sealed the `Diagnose` trait.
+
 ## [0.7.1] 2025-02-16
 
 ### Changed

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -163,7 +163,7 @@ pub(crate) use diagnostic_url;
 /// An extension trait for `Result<_, E>`, where `E` is an implementation of
 /// [`Diagnostic`], that converts `E` into [`Report<E>`](`Report`), yielding
 /// `Result<_, Report<E>>`.
-pub trait Diagnose<'s, T> {
+pub trait Diagnose<'s, T>: private::Sealed {
     /// The error type returned from `diagnose` and `diagnose_with`.
     type Error: Diagnostic;
 
@@ -222,6 +222,11 @@ where
     {
         self.map_err(|error| error.into_report(f()))
     }
+}
+
+mod private {
+    pub trait Sealed {}
+    impl<T, E> Sealed for Result<T, E> {}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
To prevent users from implementing it for their types (which doesn't really make sense). This protects us from future breaks.