### PR TITLE
migrate remaining errors to new model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+-   `EncodingError` and `ParseIndexError` now implement `Diagnostic`, which
+    unifies the API for errors originating from parse-like operations.
+-   Fixes returning an incorrect error type when parsing a `Token` that
+    terminates with `~`. This now correctly classifies the error as a `Tilde`
+    error.
+
+### Removed
+
+-   Some methods were removed from `InvalidCharacterError`, as that type no
+    longer holds a copy of the input string internally. This is a breaking
+    change. To access equivalent functionality, use the `Diagnostic` API
+    integration.
+
 ## [0.7.1] 2025-02-16
 
 ### Changed

--- a/src/assign.rs
+++ b/src/assign.rs
@@ -608,7 +608,6 @@ mod tests {
         index::{InvalidCharacterError, OutOfBoundsError, ParseIndexError},
         Pointer,
     };
-    use alloc::vec;
     use core::fmt::{Debug, Display};
 
     #[derive(Debug)]
@@ -833,6 +832,7 @@ mod tests {
     #[test]
     #[cfg(feature = "toml")]
     fn assign_toml() {
+        use alloc::vec;
         use toml::{toml, Table, Value};
         [
             Test {

--- a/src/assign.rs
+++ b/src/assign.rs
@@ -798,10 +798,7 @@ mod tests {
                 expected: Err(Error::FailedToParseIndex {
                     position: 0,
                     offset: 0,
-                    source: ParseIndexError::InvalidCharacter(InvalidCharacterError {
-                        source: "12a".into(),
-                        offset: 2,
-                    }),
+                    source: ParseIndexError::InvalidCharacter(InvalidCharacterError { offset: 2 }),
                 }),
                 expected_data: json!([]),
             },
@@ -823,10 +820,7 @@ mod tests {
                 expected: Err(Error::FailedToParseIndex {
                     position: 0,
                     offset: 0,
-                    source: ParseIndexError::InvalidCharacter(InvalidCharacterError {
-                        source: "+23".into(),
-                        offset: 0,
-                    }),
+                    source: ParseIndexError::InvalidCharacter(InvalidCharacterError { offset: 0 }),
                 }),
                 expected_data: json!([]),
             },
@@ -976,10 +970,7 @@ mod tests {
                 expected: Err(Error::FailedToParseIndex {
                     position: 0,
                     offset: 0,
-                    source: ParseIndexError::InvalidCharacter(InvalidCharacterError {
-                        source: "a".into(),
-                        offset: 0,
-                    }),
+                    source: ParseIndexError::InvalidCharacter(InvalidCharacterError { offset: 0 }),
                 }),
                 expected_data: Value::Array(vec![]),
             },

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -226,8 +226,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::{Pointer, PointerBuf};
     #[test]
     #[cfg(all(
         feature = "assign",
@@ -236,6 +234,8 @@ mod tests {
         feature = "json"
     ))]
     fn assign_error() {
+        use crate::{diagnostic::Diagnose, PointerBuf};
+
         let mut v = serde_json::json!({"foo": {"bar": ["0"]}});
         let ptr = PointerBuf::parse("/foo/bar/invalid/cannot/reach").unwrap();
         let report = ptr.assign(&mut v, "qux").diagnose(ptr).unwrap_err();
@@ -254,6 +254,7 @@ mod tests {
         feature = "json"
     ))]
     fn resolve_error() {
+        use crate::{diagnostic::Diagnose, PointerBuf};
         let v = serde_json::json!({"foo": {"bar": ["0"]}});
         let ptr = PointerBuf::parse("/foo/bar/invalid/cannot/reach").unwrap();
         let report = ptr.resolve(&v).diagnose(ptr).unwrap_err();
@@ -267,6 +268,7 @@ mod tests {
     #[test]
     #[cfg(feature = "miette")]
     fn parse_error() {
+        use crate::{diagnostic::Diagnose, Pointer, PointerBuf};
         let invalid = "/foo/bar/invalid~3~encoding/cannot/reach";
         let report = Pointer::parse(invalid).diagnose(invalid).unwrap_err();
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -35,9 +35,12 @@
 //! assert_eq!(Index::Next.for_len_unchecked(30), 30);
 //! ```
 
-use crate::Token;
+use crate::{
+    diagnostic::{diagnostic_url, IntoReport, Label},
+    Token,
+};
 use alloc::string::String;
-use core::{fmt, num::ParseIntError, str::FromStr};
+use core::{fmt, iter::once, num::ParseIntError, str::FromStr};
 
 /// Represents an abstract index into an array.
 ///
@@ -177,7 +180,6 @@ impl FromStr for Index {
                     // representing a `usize` but not allowed in RFC 6901 array
                     // indices
                     Err(ParseIndexError::InvalidCharacter(InvalidCharacterError {
-                        source: String::from(s),
                         offset,
                     }))
                 },
@@ -309,6 +311,75 @@ impl fmt::Display for ParseIndexError {
     }
 }
 
+// shouldn't be used directly, but is part of a public interface
+#[doc(hidden)]
+#[derive(Debug)]
+pub enum StringOrToken {
+    String(String),
+    Token(Token<'static>),
+}
+
+impl From<String> for StringOrToken {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<Token<'static>> for StringOrToken {
+    fn from(value: Token<'static>) -> Self {
+        Self::Token(value)
+    }
+}
+
+impl core::ops::Deref for StringOrToken {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            StringOrToken::String(s) => s.as_str(),
+            StringOrToken::Token(t) => t.encoded(),
+        }
+    }
+}
+
+impl IntoReport for ParseIndexError {
+    type Subject = StringOrToken;
+
+    fn url() -> &'static str {
+        diagnostic_url!(enum ParseIndexError)
+    }
+
+    fn labels(
+        &self,
+        subject: &Self::Subject,
+    ) -> Option<Box<dyn Iterator<Item = crate::diagnostic::Label>>> {
+        let subject = &**subject;
+        match self {
+            ParseIndexError::InvalidInteger(_) => None,
+            ParseIndexError::LeadingZeros => {
+                let len = subject
+                    .chars()
+                    .position(|c| c != '0')
+                    .expect("starts with zeros");
+                let text = String::from("leading zeros");
+                Some(Box::new(once(Label::new(text, 0, len))))
+            }
+            ParseIndexError::InvalidCharacter(err) => {
+                let len = subject
+                    .chars()
+                    .skip(err.offset)
+                    .position(|c| !c.is_ascii_digit())
+                    .expect("at least one non-digit char");
+                let text = String::from("invalid character(s)");
+                Some(Box::new(once(Label::new(text, err.offset, len))))
+            }
+        }
+    }
+}
+
+#[cfg(feature = "miette")]
+impl miette::Diagnostic for ParseIndexError {}
+
 #[cfg(feature = "std")]
 impl std::error::Error for ParseIndexError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
@@ -323,7 +394,6 @@ impl std::error::Error for ParseIndexError {
 /// Indicates that a non-digit character was found when parsing the RFC 6901 array index.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InvalidCharacterError {
-    pub(crate) source: String,
     pub(crate) offset: usize,
 }
 
@@ -334,29 +404,14 @@ impl InvalidCharacterError {
     pub fn offset(&self) -> usize {
         self.offset
     }
-
-    /// Returns the source string.
-    pub fn source(&self) -> &str {
-        &self.source
-    }
-
-    /// Returns the offending character.
-    #[allow(clippy::missing_panics_doc)]
-    pub fn char(&self) -> char {
-        self.source
-            .chars()
-            .nth(self.offset)
-            .expect("char was found at offset")
-    }
 }
 
 impl fmt::Display for InvalidCharacterError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "token contains the non-digit character '{}', \
-                which is disallowed by RFC 6901",
-            self.char()
+            "token contains a non-digit character, \
+            which is disallowed by RFC 6901",
         )
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -36,7 +36,7 @@
 //! ```
 
 use crate::{
-    diagnostic::{diagnostic_url, IntoReport, Label},
+    diagnostic::{diagnostic_url, Diagnostic, Label},
     Token,
 };
 use alloc::string::String;
@@ -342,7 +342,7 @@ impl core::ops::Deref for StringOrToken {
     }
 }
 
-impl IntoReport for ParseIndexError {
+impl Diagnostic for ParseIndexError {
     type Subject = StringOrToken;
 
     fn url() -> &'static str {

--- a/src/index.rs
+++ b/src/index.rs
@@ -597,4 +597,18 @@ mod tests {
 
         assert_eq!(labels, vec![Label::new("leading zeros".into(), 0, 5)]);
     }
+
+    #[test]
+    fn error_from_empty_string() {
+        let s = String::from("");
+        let err = Index::try_from(&s).diagnose(s).unwrap_err();
+
+        #[cfg(feature = "miette")]
+        {
+            assert!(miette::Diagnostic::labels(&err).is_none());
+        }
+
+        let (src, sub) = err.decompose();
+        assert!(src.labels(&sub).is_none());
+    }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -39,7 +39,7 @@ use crate::{
     diagnostic::{diagnostic_url, Diagnostic, Label},
     Token,
 };
-use alloc::string::String;
+use alloc::{boxed::Box, string::String};
 use core::{fmt, iter::once, num::ParseIntError, str::FromStr};
 
 /// Represents an abstract index into an array.

--- a/src/token.rs
+++ b/src/token.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use alloc::{
     borrow::Cow,
+    boxed::Box,
     fmt,
     string::{String, ToString},
     vec::Vec,

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,7 +1,7 @@
 use core::{iter::once, str::Split};
 
 use crate::{
-    diagnostic::{diagnostic_url, IntoReport, Label},
+    diagnostic::{diagnostic_url, Diagnostic, Label},
     index::{Index, ParseIndexError},
 };
 use alloc::{
@@ -394,7 +394,7 @@ impl fmt::Display for EncodingError {
     }
 }
 
-impl IntoReport for EncodingError {
+impl Diagnostic for EncodingError {
     type Subject = String;
 
     fn url() -> &'static str {


### PR DESCRIPTION
The `EncodingError` and `ParseIndexError` types are parsing errors with a
well defined 'subject', but they weren't previously made into `Diagnostic`
implementors, so they worked a bit inconsistently with other error types. This
PR makes it so those errors follow the same conventions and general structure
used by its kindred.

There is one related breaking change: `InvalidCharacterError` previously held
a copy of the subject, but in the new model this is a responsibility of its
enriched `Report<InvalidCharacterError>` type. Since some methods directly
depended on access to the subject, they had to be removed. I think this is
justifiable since the new error APIs are already breaking (we just should've
made this change in tandem with the other related breaks).

I don't have any other error-related breaks planned.

This PR also incidentally fixes an incorrect error type returned if the token ended with a `~` (it would be flagged as a slash error, not tilde). I updated tests to cover this.