### PR TITLE
fix overly strict lifetime bound in Default impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+-   Implementation of the `Default` trait for `Pointer` now doesn't constrain the lifetime.
+
 ## [0.7.1] 2025-02-16
 
 ### Changed

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -36,7 +36,7 @@ mod slice;
 #[cfg_attr(not(doc), repr(transparent))]
 pub struct Pointer(str);
 
-impl Default for &'static Pointer {
+impl Default for &Pointer {
     fn default() -> Self {
         Pointer::root()
     }
@@ -2341,5 +2341,14 @@ mod tests {
         let boxed: Box<Pointer> = subjectal.clone().into();
         let unboxed = boxed.into_buf();
         assert_eq!(subjectal, unboxed);
+    }
+
+    #[test]
+    fn default_lifetime_is_correct() {
+        // if this compiles, we're good
+        #[allow(dead_code)]
+        fn or_default(ptr: &Pointer) -> &Pointer {
+            Some(ptr).unwrap_or_default()
+        }
     }
 }

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -2346,9 +2346,10 @@ mod tests {
     #[test]
     fn default_lifetime_is_correct() {
         // if this compiles, we're good
-        #[allow(dead_code)]
         fn or_default(ptr: &Pointer) -> &Pointer {
             Some(ptr).unwrap_or_default()
         }
+        // just to satisfy codecov and clippy
+        or_default(Pointer::root());
     }
 }


### PR DESCRIPTION
This one is a bit subtle. It causes some code relying on the `Default` trait implementation to be rejected by the compiler:

```rust
fn or_default(ptr: &Pointer) -> &Pointer {
    Some(ptr).unwrap_or_default()
}
```

This is because this desugars to:

```rust
match self {
    Some(x) => x, // '_
    None => Self::default() // 'static
}
```

Which demands that `'_ == 'static` to be accepted. This is overly strict, we should coerce to whatever lifetime the original `&` had instead.