### PR TITLE
README: Fix `Delete` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ use jsonptr::Pointer;
 use serde_json::json;
 
 let ptr = Pointer::parse("/secret/universe").unwrap();
-let mut data = json!({"secret": { "universe": 42 }});
-let replaced = ptr.assign(&mut data, json!(34)).unwrap();
-assert_eq!(replaced, Some(json!(42)));
-assert_eq!(data, json!({"secret": { "universe": 34 }}));
+let mut data = json!({"secret": { "life": 42, "universe": 42, "everything": 42 }});
+let deleted = ptr.delete(&mut data);
+assert_eq!(deleted, Some(json!(42)));
+assert_eq!(data, json!({"secret": { "life": 42, "everything": 42 }}));
 ```
 
 ### Error Reporting

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -398,7 +398,7 @@ impl Pointer {
     /// [`Delete`]. The supplied implementations (`"json"` & `"toml"`) operate
     /// as follows:
     /// - If the `Pointer` can be resolved, the `Value` is deleted and returned.
-    /// - If the `Pointer` fails to resolve for any reason, `Ok(None)` is returned.
+    /// - If the `Pointer` fails to resolve for any reason, `None` is returned.
     /// - If the `Pointer` is root, `value` is replaced:
     ///     - `"json"`: `serde_json::Value::Null`
     ///     - `"toml"`: `toml::Value::Table::Default`


### PR DESCRIPTION
Seems like this was accidentally left as a copy-paste of the `Assign` example. I took the liberty to add some extra keys to the object which we're deleting from, as I think it makes it a bit clearer what's happening than:

    { "secret": { "universe": 42 }} -> { "secret": {} }

Which confused me a bit at first (but that might just be me).