### PR TITLE
Bump versions and deny default features of serde crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,18 +339,18 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -359,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ version = "0.7.1"
 
 [dependencies]
 miette     = { version = "7.4.0", optional = true, features = ["fancy"] }
-serde      = { version = "1.0.203", optional = true, features = ["alloc"] }
-serde_json = { version = "1.0.119", optional = true, features = ["alloc"] }
+serde      = { version = "1.0.219", optional = true, default-features = false, features = ["alloc"] }
+serde_json = { version = "1.0.140", optional = true, default-features = false, features = ["alloc"] }
 toml       = { version = "0.8", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This change makes `jsonptr` compatible with no-std environments when using the `json` feature flag.