### PR TITLE
Fix panic when deleting an array index equal to the array length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-   `Delete::delete` no longer panics when a pointer's final token resolves to
+    an array index equal to the array's length (e.g. `-` on any array, or a
+    numeric index equal to the length). It now returns `None` and leaves the
+    document unmodified, as documented. Fixes
+    [#120](https://github.com/chanced/jsonptr/issues/120).
 -   `EncodingError` and `ParseIndexError` now implement `Diagnostic`, which
     unifies the API for errors originating from parse-like operations.
 -   Fixes returning an incorrect error type when parsing a `Token` that

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -105,7 +105,7 @@ mod json {
                 .ok()
                 .and_then(|parent| match parent {
                     Value::Array(children) => {
-                        let idx = last.to_index().ok()?.for_len_incl(children.len()).ok()?;
+                        let idx = last.to_index().ok()?.for_len(children.len()).ok()?;
                         children.remove(idx).into()
                     }
                     Value::Object(children) => children.remove(last.decoded().as_ref()),
@@ -143,7 +143,7 @@ mod toml {
                 .ok()
                 .and_then(|parent| match parent {
                     Value::Array(children) => {
-                        let idx = last.to_index().ok()?.for_len_incl(children.len()).ok()?;
+                        let idx = last.to_index().ok()?.for_len(children.len()).ok()?;
                         children.remove(idx).into()
                     }
                     Value::Table(children) => children.remove(last.decoded().as_ref()),
@@ -269,6 +269,38 @@ mod tests {
                 expected_data: json!(null),
                 expected_deleted: Some(json!({"Example": 21, "test": "test"})),
             },
+            // 9
+            // issue #120 - `-` on an array must miss rather than panic
+            Test {
+                ptr: "/-",
+                data: json!([1, 2, 3]),
+                expected_data: json!([1, 2, 3]),
+                expected_deleted: None,
+            },
+            // 10
+            // issue #120 - numeric index equal to the array length misses
+            Test {
+                ptr: "/3",
+                data: json!([1, 2, 3]),
+                expected_data: json!([1, 2, 3]),
+                expected_deleted: None,
+            },
+            // 11
+            // issue #120 - `/0` on an empty array misses
+            Test {
+                ptr: "/0",
+                data: json!([]),
+                expected_data: json!([]),
+                expected_deleted: None,
+            },
+            // 12
+            // issue #120 - nested `-` on an array misses
+            Test {
+                ptr: "/foo/-",
+                data: json!({"foo": [1, 2]}),
+                expected_data: json!({"foo": [1, 2]}),
+                expected_deleted: None,
+            },
         ]);
     }
     /*
@@ -338,6 +370,22 @@ mod tests {
                 ptr: "/Example",
                 expected_data: toml! {"test" = "test"}.into(),
                 expected_deleted: Some(21.into()),
+            },
+            // 8
+            // issue #120 - `-` on an array must miss rather than panic
+            Test {
+                data: toml! {"foo" = [1, 2, 3]}.into(),
+                ptr: "/foo/-",
+                expected_data: toml! {"foo" = [1, 2, 3]}.into(),
+                expected_deleted: None,
+            },
+            // 9
+            // issue #120 - numeric index equal to the array length misses
+            Test {
+                data: toml! {"foo" = [1, 2, 3]}.into(),
+                ptr: "/foo/3",
+                expected_data: toml! {"foo" = [1, 2, 3]}.into(),
+                expected_deleted: None,
             },
         ]);
     }


### PR DESCRIPTION
## Summary

Fixes #120.

`Delete::delete` panicked instead of returning `None` when a pointer's final token resolved to an array index equal to the array's length. The RFC 6901 `-` token always resolves to that index, so a pointer parsed from untrusted input (e.g. a JSON Patch `remove` op with path `/-`) reached the panic.

```
removal index (is 3) should be < len (is 3)
```

## Root cause

Both the `json` and `toml` impls used the **inclusive** bound helper `for_len_incl`, which admits `index == len` and maps `Index::Next` (`-`) to `len`. The result was passed straight to `Vec::remove`, which requires `index < len`.

## Fix

Switch to the **exclusive** helper `for_len`, which rejects `Next` and any numeric index `>= len`, so `.ok()?` cleanly yields `None`. This matches what `resolve` already does and the documented contract that an unresolvable pointer returns `None` with the document unmodified.

## Tests

Added out-of-bounds delete cases to both the `delete_json` and `delete_toml` suites:
- `-` on an array
- a numeric index equal to the array length
- `/0` on an empty array
- a nested `/foo/-`

Full suite passes with `--all-features`.