### PR TITLE
Unblock CI and bump to 0.8.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,6 +151,11 @@ jobs:
             - name: Upload to codecov.io
               uses: codecov/codecov-action@v4
               with:
-                  fail_ci_if_error: true
+                  # Dependabot and fork PRs don't have access to CODECOV_TOKEN
+                  # (secrets are withheld from untrusted contexts), so codecov
+                  # can't create a commit on the protected branch and the upload
+                  # errors. Only treat that error as fatal for trusted PRs and
+                  # pushes to main, where the token is available.
+                  fail_ci_if_error: ${{ !(github.event.pull_request.head.repo.fork == true || github.actor == 'dependabot[bot]') }}
                   token: ${{ secrets.CODECOV_TOKEN }}
                   env_vars: OS,RUST

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.8.0] 2026-07-26
+
 ### Deprecated
 
 -   Deprecated `ResolveError` name.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jsonptr"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "miette",
  "quickcheck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 name = "jsonptr"
 repository = "https://github.com/chanced/jsonptr"
 rust-version = "1.79.0"
-version = "0.7.1"
+version = "0.8.0"
 
 [dependencies]
 miette     = { version = "7.4.0", optional = true, features = ["fancy"] }


### PR DESCRIPTION
> **Note:** This PR was merged early and captured only its first commit (the CI unblock + version bump). Two follow-up commits pushed to the branch afterward — the stale-deprecation fix and the `split_at` / `split_at_offset` work — did **not** land here; they moved to **#123**. This description has been corrected to describe what actually merged.

## What actually merged here

Unblocks CI, which had two checks failing on **every** PR (including the Dependabot bumps #118/#119) for reasons unrelated to the PRs that tripped them:

- **`semver`** — `main` was still versioned `0.7.1` (the last published release) despite accumulating breaking changes since that tag (sealed `Diagnose` #107, removed `InvalidCharacterError` methods #108). Fixed by bumping to `0.8.0` (a minor bump, which permits breaking changes for a `0.x` crate) and rolling the CHANGELOG's `Unreleased` section into a dated `0.8.0` entry.
- **`coverage`** — `CODECOV_TOKEN` isn't available to Dependabot/fork PRs, so the upload errored with *"Token required because branch is protected."* `fail_ci_if_error` is now conditional: fatal only on trusted PRs and pushes to `main`.

## Remainder of 0.8.0

The rest of the 0.8.0 release prep is in **#123**:
- Fix the stale `#[deprecated(since = "0.7.2")]` on the `ResolveError` alias (→ `0.8.0`).
- Deprecate `Pointer::split_at`, add `Pointer::split_at_offset` (folds in #89).
