### PR TITLE
Resolve all clippy and rustc lint warnings across the feature powerset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+-   Resolved all `clippy` (`clippy::all` + `clippy::pedantic`) and `rustc` lint
+    warnings across the full feature powerset — including newer-toolchain lints
+    (`mismatched_lifetime_syntaxes`) and feature-combination dead-code warnings.
+    Internal only; no public API changes.
+
 ## [0.8.0] 2026-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ In the case of [`PointerBuf::parse`], the [`ParseError`] is always wrapped in a
 Licensed under either of
 
 -   Apache License, Version 2.0
-    ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+    ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
 -   MIT license
-    ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+    ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your convenience.
 

--- a/src/assign.rs
+++ b/src/assign.rs
@@ -216,6 +216,7 @@ impl Diagnostic for Error {
     }
 
     fn labels(&self, origin: &Self::Subject) -> Option<Box<dyn Iterator<Item = Label>>> {
+        use alloc::format;
         let position = self.position();
         let token = origin.get(position)?;
         let offset = if self.offset() + 1 < origin.as_str().len() {
@@ -264,6 +265,7 @@ mod json {
     use serde_json::{map::Entry, Map, Value};
 
     fn expand(mut remaining: &Pointer, mut value: Value) -> Value {
+        use alloc::vec;
         while let Some((ptr, tok)) = remaining.split_back() {
             remaining = ptr;
             match tok.encoded() {
@@ -430,11 +432,12 @@ mod json {
 mod toml {
     use super::{Assign, Assigned, Error};
     use crate::{Pointer, Token};
-    use alloc::{string::String, vec, vec::Vec};
+    use alloc::{string::String, vec::Vec};
     use core::mem;
     use toml::{map::Entry, map::Map, Value};
 
     fn expand(mut remaining: &Pointer, mut value: Value) -> Value {
+        use alloc::vec;
         while let Some((ptr, tok)) = remaining.split_back() {
             remaining = ptr;
             match tok.encoded() {
@@ -595,6 +598,8 @@ mod toml {
     }
 }
 
+// `Assigned` is only referenced by the `json` and `toml` assignment impls.
+#[cfg(any(feature = "json", feature = "toml"))]
 enum Assigned<'v, V> {
     Done(Option<V>),
     Continue { next_dest: &'v mut V, same_value: V },

--- a/src/index.rs
+++ b/src/index.rs
@@ -350,7 +350,7 @@ impl miette::SourceCode for StringOrToken {
         context_lines_before: usize,
         context_lines_after: usize,
     ) -> Result<Box<dyn miette::SpanContents<'a> + 'a>, miette::MietteError> {
-        let s: &str = &**self;
+        let s: &str = self;
         s.read_span(span, context_lines_before, context_lines_after)
     }
 }
@@ -552,10 +552,7 @@ mod tests {
 
         #[cfg(feature = "miette")]
         {
-            let labels: Vec<_> = miette::Diagnostic::labels(&err)
-                .unwrap()
-                .into_iter()
-                .collect();
+            let labels: Vec<_> = miette::Diagnostic::labels(&err).unwrap().collect();
             assert_eq!(
                 labels,
                 vec![miette::LabeledSpan::new(
@@ -567,7 +564,7 @@ mod tests {
         }
 
         let (src, sub) = err.decompose();
-        let labels: Vec<_> = src.labels(&sub).unwrap().into_iter().collect();
+        let labels: Vec<_> = src.labels(&sub).unwrap().collect();
 
         assert_eq!(
             labels,
@@ -582,10 +579,7 @@ mod tests {
 
         #[cfg(feature = "miette")]
         {
-            let labels: Vec<_> = miette::Diagnostic::labels(&err)
-                .unwrap()
-                .into_iter()
-                .collect();
+            let labels: Vec<_> = miette::Diagnostic::labels(&err).unwrap().collect();
             assert_eq!(
                 labels,
                 vec![miette::LabeledSpan::new(Some("leading zeros".into()), 0, 5)]
@@ -593,14 +587,14 @@ mod tests {
         }
 
         let (src, sub) = err.decompose();
-        let labels: Vec<_> = src.labels(&sub).unwrap().into_iter().collect();
+        let labels: Vec<_> = src.labels(&sub).unwrap().collect();
 
         assert_eq!(labels, vec![Label::new("leading zeros".into(), 0, 5)]);
     }
 
     #[test]
     fn error_from_empty_string() {
-        let s = String::from("");
+        let s = String::new();
         let err = Index::try_from(&s).diagnose(s).unwrap_err();
 
         #[cfg(feature = "miette")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,6 @@
     clippy::similar_names
 )]
 
-#[cfg_attr(not(feature = "std"), macro_use)]
 extern crate alloc;
 
 #[cfg(feature = "assign")]

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -117,7 +117,7 @@ impl Pointer {
     }
 
     /// Returns an iterator of `Token`s in the `Pointer`.
-    pub fn tokens(&self) -> Tokens {
+    pub fn tokens(&self) -> Tokens<'_> {
         let mut s = self.0.split('/');
         // skipping the first '/'
         s.next();
@@ -141,7 +141,7 @@ impl Pointer {
     }
 
     /// Returns the last `Token` in the `Pointer`.
-    pub fn back(&self) -> Option<Token> {
+    pub fn back(&self) -> Option<Token<'_>> {
         self.0
             .rsplit_once('/')
             // SAFETY: pointer is encoded
@@ -151,12 +151,12 @@ impl Pointer {
     /// Returns the last token in the `Pointer`.
     ///
     /// alias for `back`
-    pub fn last(&self) -> Option<Token> {
+    pub fn last(&self) -> Option<Token<'_>> {
         self.back()
     }
 
     /// Returns the first `Token` in the `Pointer`.
-    pub fn front(&self) -> Option<Token> {
+    pub fn front(&self) -> Option<Token<'_>> {
         if self.is_root() {
             return None;
         }
@@ -173,12 +173,12 @@ impl Pointer {
     /// Returns the first `Token` in the `Pointer`.
     ///
     /// alias for `front`
-    pub fn first(&self) -> Option<Token> {
+    pub fn first(&self) -> Option<Token<'_>> {
         self.front()
     }
 
     /// Splits the `Pointer` into the first `Token` and a remainder `Pointer`.
-    pub fn split_front(&self) -> Option<(Token, &Self)> {
+    pub fn split_front(&self) -> Option<(Token<'_>, &Self)> {
         if self.is_root() {
             return None;
         }
@@ -255,7 +255,7 @@ impl Pointer {
     }
 
     /// Splits the `Pointer` into the parent path and the last `Token`.
-    pub fn split_back(&self) -> Option<(&Self, Token)> {
+    pub fn split_back(&self) -> Option<(&Self, Token<'_>)> {
         self.0.rsplit_once('/').map(|(front, back)| {
             (
                 // SAFETY: we split at a token boundary, so front is a valid pointer
@@ -503,7 +503,7 @@ impl Pointer {
     /// assert_eq!(components.next(), Some(Component::Token("b".into())));
     /// assert_eq!(components.next(), None);
     /// ```
-    pub fn components(&self) -> Components {
+    pub fn components(&self) -> Components<'_> {
         self.into()
     }
 
@@ -640,6 +640,7 @@ impl<'de: 'p, 'p> serde::Deserialize<'de> for &'p Pointer {
             where
                 E: Error,
             {
+                use alloc::format;
                 Pointer::parse(v).map_err(|err| {
                     Error::custom(format!("failed to parse json pointer\n\ncaused by:\n{err}"))
                 })
@@ -1022,7 +1023,7 @@ impl PointerBuf {
         &mut self,
         index: usize,
         token: impl Into<Token<'t>>,
-    ) -> Result<Option<Token>, ReplaceError> {
+    ) -> Result<Option<Token<'_>>, ReplaceError> {
         if self.is_root() {
             return Err(ReplaceError {
                 count: self.count(),
@@ -2380,7 +2381,10 @@ mod tests {
 
     #[test]
     fn default_lifetime_is_correct() {
-        // if this compiles, we're good
+        // if this compiles, we're good: `unwrap_or_default` exercises
+        // `<&Pointer as Default>::default()` and must type-check with the
+        // borrowed lifetime (regression test for #111).
+        #[allow(clippy::unnecessary_literal_unwrap)]
         fn or_default(ptr: &Pointer) -> &Pointer {
             Some(ptr).unwrap_or_default()
         }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -36,8 +36,11 @@
 use crate::{
     diagnostic::{diagnostic_url, Diagnostic, Label},
     index::{OutOfBoundsError, ParseIndexError},
-    Pointer, PointerBuf, Token,
+    Pointer, PointerBuf,
 };
+// `Token` is only referenced by the `json`-gated `parse_index`.
+#[cfg(feature = "json")]
+use crate::Token;
 use alloc::{boxed::Box, string::ToString};
 use core::iter::once;
 
@@ -344,6 +347,8 @@ mod json {
         }
     }
 }
+// `parse_index` is only referenced by the `json` resolve impl.
+#[cfg(feature = "json")]
 fn parse_index(
     token: Token,
     array_len: usize,

--- a/src/token.rs
+++ b/src/token.rs
@@ -510,15 +510,12 @@ mod tests {
 
         let sub = String::from("a/b");
         let err = Token::from_encoded(&sub).unwrap_err();
-        let labels: Vec<_> = err.labels(&sub).unwrap().into_iter().collect();
+        let labels: Vec<_> = err.labels(&sub).unwrap().collect();
         assert_eq!(labels, vec![Label::new("invalid character".into(), 1, 1)]);
         let err = err.into_report(sub);
         #[cfg(feature = "miette")]
         {
-            let labels: Vec<_> = miette::Diagnostic::labels(&err)
-                .unwrap()
-                .into_iter()
-                .collect();
+            let labels: Vec<_> = miette::Diagnostic::labels(&err).unwrap().collect();
             assert_eq!(
                 labels,
                 vec![miette::LabeledSpan::new(
@@ -539,15 +536,12 @@ mod tests {
 
         let sub = String::from("a~a");
         let err = Token::from_encoded(&sub).unwrap_err();
-        let labels: Vec<_> = err.labels(&sub).unwrap().into_iter().collect();
+        let labels: Vec<_> = err.labels(&sub).unwrap().collect();
         assert_eq!(labels, vec![Label::new("must be 0 or 1".into(), 2, 1)]);
         let err = err.into_report(sub);
         #[cfg(feature = "miette")]
         {
-            let labels: Vec<_> = miette::Diagnostic::labels(&err)
-                .unwrap()
-                .into_iter()
-                .collect();
+            let labels: Vec<_> = miette::Diagnostic::labels(&err).unwrap().collect();
             assert_eq!(
                 labels,
                 vec![miette::LabeledSpan::new(
@@ -567,7 +561,7 @@ mod tests {
         );
         let sub = String::from("a~");
         let err = Token::from_encoded(&sub).unwrap_err();
-        let labels: Vec<_> = err.labels(&sub).unwrap().into_iter().collect();
+        let labels: Vec<_> = err.labels(&sub).unwrap().collect();
         assert_eq!(
             labels,
             vec![Label::new("incomplete escape sequence".into(), 1, 1)]
@@ -575,10 +569,7 @@ mod tests {
         let err = err.into_report(sub);
         #[cfg(feature = "miette")]
         {
-            let labels: Vec<_> = miette::Diagnostic::labels(&err)
-                .unwrap()
-                .into_iter()
-                .collect();
+            let labels: Vec<_> = miette::Diagnostic::labels(&err).unwrap().collect();
             assert_eq!(
                 labels,
                 vec![miette::LabeledSpan::new(


### PR DESCRIPTION
Resolves **all** `clippy` and `rustc` lint warnings across the full feature powerset, prep for the next release. **No public API changes** — internal/tooling only, so no version bump here.

## What was flagged & fixed

**`clippy::all` / `clippy::pedantic` errors** (the crate denies both at `lib.rs:38`):
- `explicit_auto_deref` in `StringOrToken::read_span` (`&**self` → `self`).
- Redundant `.into_iter()` before `.collect()` and `String::from("")` → `String::new()` in tests.
- Bare URLs in `README.md` (included as crate docs via `#![doc = include_str!]`) wrapped in `<…>`.

**Newer-toolchain rustc lint** `mismatched_lifetime_syntaxes` (9 sites): made elided output lifetimes explicit in `pointer.rs` public signatures — `Tokens<'_>`, `Token<'_>`, `Components<'_>`. Purely syntactic; the API is unchanged.

**`#[macro_use] extern crate alloc`**: removed. It was unused in the minimal feature set (warning under `--no-default-features`). `vec!`/`format!` are now imported where used — inline `use` for single-use sites, matching the codebase's existing style.

**Feature-combination dead code**: gated items so they don't warn when their consumer features are off — `Assigned` (`json`/`toml`), and `parse_index` + its `Token` import (`json`).

## Verification

- `cargo hack --feature-powerset --no-dev-deps clippy` → **0 warnings**
- `cargo clippy --all-features --all-targets` → **clean**
- `cargo test --all-features` → 104 + 48 pass; `cargo fmt --check` clean

One note: `clippy --fix` tried to reduce `Some(ptr).unwrap_or_default()` to `ptr` in the `default_lifetime_is_correct` regression test (#111), which would remove what the test checks. That was reverted and given a local `#[allow(clippy::unnecessary_literal_unwrap)]` instead.
