### PR TITLE
Add Token::into_encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+-   Added `Token::into_encoded`, which consumes the `Token` and returns its
+    encoded string representation as a `Cow<'a, str>` without allocating.
+    Resolves [#115](https://github.com/chanced/jsonptr/issues/115).
+
 ### Changed
 
 -   Resolved all `clippy` (`clippy::all` + `clippy::pedantic`) and `rustc` lint

--- a/src/token.rs
+++ b/src/token.rs
@@ -197,6 +197,22 @@ impl<'a> Token<'a> {
         &self.inner
     }
 
+    /// Converts this `Token` into the encoded string representation, as a
+    /// `Cow<'a, str>`.
+    ///
+    /// This is like [`Self::encoded`], except it consumes the `Token` and,
+    /// since the token is already encoded internally, does not allocate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use jsonptr::Token;
+    /// assert_eq!(Token::new("~bar").into_encoded(), "~0bar");
+    /// ```
+    pub fn into_encoded(self) -> Cow<'a, str> {
+        self.inner
+    }
+
     /// Returns the decoded string representation of the `Token`.
     ///
     /// # Examples
@@ -587,6 +603,15 @@ mod tests {
                 source: InvalidEncoding::Tilde
             }
         );
+    }
+
+    #[test]
+    fn into_encoded() {
+        let token = Token::from_encoded("foo~0").unwrap();
+        assert_eq!(token.into_encoded(), "foo~0");
+
+        let token = Token::new("~bar");
+        assert_eq!(token.into_encoded(), "~0bar");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `Token::into_encoded(self) -> Cow<'a, str>`, which consumes the Token and returns its encoded string representation.
- Since the Token internal representation is already RFC 6901 encoded, this is a plain move of the inner Cow -- no allocation.

Closes #115.

## Test plan
- [x] cargo test --lib token
- [x] cargo test --doc token
- [x] cargo clippy --all-features