### PR TITLE
Fix broken/stale intra-doc links and export ReplaceError

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ dual licensed as above, without any additional terms or conditions.
 [`serde`]: https://docs.rs/serde/1.0/serde/index
 [`serde_json`]: https://docs.rs/serde_json/1.0/serde_json/enum.Value.html
 [`serde_json::Value`]: https://docs.rs/serde_json/1.0/serde_json/enum.Value.html
-[`toml`]: https://docs.rs/toml/0.8/toml/enum.Value.html
-[`toml::Value`]: https://docs.rs/toml/0.8/toml/enum.Value.html
+[`toml`]: https://docs.rs/toml/0.9/toml/enum.Value.html
+[`toml::Value`]: https://docs.rs/toml/0.9/toml/enum.Value.html
 [`Path`]: https://doc.rust-lang.org/std/path/struct.Path.html
 [`PathBuf`]: https://doc.rust-lang.org/std/path/struct.PathBuf.html

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -17,7 +17,7 @@ pub trait Diagnostic: Sized {
     /// The docs.rs URL for this error
     fn url() -> &'static str;
 
-    /// Returns the label for the given [`Subject`] if applicable.
+    /// Returns the label for the given [`Subject`](Diagnostic::Subject) if applicable.
     fn labels(&self, subject: &Self::Subject) -> Option<Box<dyn Iterator<Item = Label>>>;
 }
 
@@ -51,8 +51,8 @@ impl From<Label> for miette::LabeledSpan {
 ///
 /// This type serves two roles:
 ///
-/// 1. **[`PointerBuf::parse`]**: Captures the [`ParseError`] along with the
-///    input `String`.
+/// 1. **[`PointerBuf::parse`](crate::PointerBuf::parse)**: Captures the
+///    [`ParseError`](crate::ParseError) along with the input `String`.
 ///
 /// 2. **Reporting:** Provides enriched reporting capabilities, including
 ///    (optional) `miette` integration, for `ParseError` and associated  errors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! [`tokens`]: crate::Pointer::tokens
 //! [`components`]: crate::Pointer::components
 //! [`resolve`]: crate::resolve
-//! [`assign`]: crate::asign
+//! [`assign`]: crate::assign
 //! [`delete`]: crate::delete
 //! [`Resolve`]: crate::resolve::Resolve
 //! [`ResolveMut`]: crate::resolve::ResolveMut
@@ -28,8 +28,8 @@
 //! [`serde`]: https://docs.rs/serde/1.0/serde/index
 //! [`serde_json`]: https://docs.rs/serde_json/1.0/serde_json/enum.Value.html
 //! [`serde_json::Value`]: https://docs.rs/serde_json/1.0/serde_json/enum.Value.html
-//! [`toml`]: https://docs.rs/toml/0.8/toml/enum.Value.html
-//! [`toml::Value`]: https://docs.rs/toml/0.8/toml/enum.Value.html
+//! [`toml`]: https://docs.rs/toml/0.9/toml/enum.Value.html
+//! [`toml::Value`]: https://docs.rs/toml/0.9/toml/enum.Value.html
 //! [`Path`]: https://doc.rust-lang.org/std/path/struct.Path.html
 //! [`PathBuf`]: https://doc.rust-lang.org/std/path/struct.PathBuf.html
 
@@ -67,7 +67,7 @@ pub mod diagnostic;
 pub use diagnostic::{Diagnose, Report};
 
 mod pointer;
-pub use pointer::{ParseError, Pointer, PointerBuf, RichParseError};
+pub use pointer::{ParseError, Pointer, PointerBuf, ReplaceError, RichParseError};
 
 mod token;
 pub use token::{EncodingError, InvalidEncoding, Token, Tokens};

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -568,10 +568,10 @@ impl Pointer {
         buf
     }
 
-    //  Returns the length of `self` in encoded format.
+    /// Returns the length of `self` in encoded format.
     ///
     /// This length expresses the byte count of the underlying string that
-    /// represents the RFC 6091 Pointer. See also [`std::str::len`].
+    /// represents the RFC 6901 Pointer. See also [`str::len`].
     ///
     /// ## Examples
     /// ```

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -9,7 +9,7 @@
 //! ## Usage
 //! [`Resolve`] and [`ResolveMut`] can be used directly or through the
 //! [`resolve`](Pointer::resolve) and [`resolve_mut`](Pointer::resolve_mut)
-//! methods on [`Pointer`] and [`PointerBuf`](crate::PointerBuf).
+//! methods on [`Pointer`] and [`PointerBuf`].
 //!
 //! ```rust
 //! use jsonptr::{Pointer, Resolve, ResolveMut};
@@ -106,8 +106,8 @@ pub enum Error {
         source: ParseIndexError,
     },
 
-    /// A [`Token`] within the [`Pointer`] contains an [`Index`] which is out of
-    /// bounds.
+    /// A [`Token`] within the [`Pointer`] contains an
+    /// [`Index`](crate::index::Index) which is out of bounds.
     ///
     /// ## Example
     /// ```rust


### PR DESCRIPTION
## Summary
- Fixed a broken intra-doc link typo (`crate::asign` -> `crate::assign`) and an `RFC 6091` -> `RFC 6901` typo
- Fixed a doc comment on `Pointer::len` that used `//` instead of `///` and was silently dropped from rendered docs
- Updated stale `docs.rs/toml/0.8/...` links to `0.9` (matching the `toml` dependency bump)
- Exported `ReplaceError` (returned by `PointerBuf::replace`) from the crate root — it was `pub` but unreachable since `mod pointer` is private, so callers had no way to name the error type
- Fixed assorted unresolved/redundant intra-doc links in `resolve.rs` and `diagnostic.rs`

## Test plan
- [x] `cargo doc --all-features` — 0 warnings (was 8)
- [x] `cargo test --all-features` — all tests pass
- [x] `cargo clippy --all-features --all-targets` — clean