### PR TITLE
Release jsonptr version 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.8.1] 2026-07-26
+
 ### Added
 
 -   Added `Token::into_encoded`, which consumes the `Token` and returns its
     encoded string representation as a `Cow<'a, str>` without allocating.
     Resolves [#115](https://github.com/chanced/jsonptr/issues/115).
+-   `ReplaceError` (returned by `PointerBuf::replace`) is now re-exported from
+    the crate root, so callers can actually name the type.
 
 ### Changed
 
@@ -19,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     warnings across the full feature powerset — including newer-toolchain lints
     (`mismatched_lifetime_syntaxes`) and feature-combination dead-code warnings.
     Internal only; no public API changes.
+
+### Fixed
+
+-   Fixed several broken/stale intra-doc links (a `crate::asign` typo, an "RFC
+    6091" typo, stale `toml` docs.rs links pointing at 0.8 instead of 0.9) and
+    a doc comment on `Pointer::len` that used `//` instead of `///` and was
+    silently dropped from rendered docs.
 
 ## [0.8.0] 2026-07-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jsonptr"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "miette",
  "quickcheck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 name = "jsonptr"
 repository = "https://github.com/chanced/jsonptr"
 rust-version = "1.79.0"
-version = "0.8.0"
+version = "0.8.1"
 
 [dependencies]
 miette     = { version = "7.4.0", optional = true, features = ["fancy"] }


### PR DESCRIPTION
## Summary
- Bumps Cargo.toml/Cargo.lock to 0.8.1.
- Rolls the CHANGELOG Unreleased section into a versioned 0.8.1 entry: Token::into_encoded from PR 125, closing issue 115; the clippy/rustc lint powerset cleanup from PR 124; and the doc-link fixes from PR 126, which also documents the new ReplaceError re-export.

## Test plan
- [x] cargo build --all-features
- [x] cargo test --all-features
- [x] cargo clippy --all-features --all-targets